### PR TITLE
Support non nbd devices to be provided for encryption

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -454,10 +454,6 @@ func (d *imageDeployer) run(opts *deployOptions) error {
 	d.enterScope()
 	defer d.exitScope()
 
-	if err := d.checkPrerequisitesBase(); err != nil {
-		return err
-	}
-
 	if opts.StandardSRKTemplate && opts.SRKTemplateUniqueData != "" {
 		return errors.New("cannot specify both --standard-srk-template and --srk-template-unique-data")
 	}
@@ -474,10 +470,20 @@ func (d *imageDeployer) run(opts *deployOptions) error {
 	if fi.Mode()&os.ModeDevice != 0 {
 		// Source file is a block device
 		d.devPath = opts.Positional.Input
+		if d.isNbdDevice() {
+			if err := d.checkNbdPreRequisites(); err != nil {
+				return err
+			}
+		}
+
 		return d.deployImageOnDevice()
 	}
 
 	// Source file is not a block device
+	if err := d.checkNbdPreRequisites(); err != nil {
+		return err
+	}
+
 	return d.deployImageFromFile()
 }
 

--- a/deploy.go
+++ b/deploy.go
@@ -42,7 +42,6 @@ import (
 
 	"github.com/canonical/encrypt-cloud-image/internal/efienv"
 	"github.com/canonical/encrypt-cloud-image/internal/luks2"
-	"github.com/canonical/encrypt-cloud-image/internal/nbd"
 )
 
 type deployOptions struct {
@@ -321,7 +320,12 @@ func (d *imageDeployer) readKeyFromImage() (key []byte, removeToken func() error
 	log.Infoln("reading key from LUKS2 container")
 
 	for _, partition := range d.partitions {
-		path := fmt.Sprintf(d.devPathFormat, d.devPath, partition.Index)
+		devPathFormat, err := d.getDevPathFormat()
+		if err != nil {
+			return nil, nil, errors.New(err.Error())
+		}
+
+		path := fmt.Sprintf(devPathFormat, d.devPath, partition.Index)
 		log.Debugln("trying", path)
 
 		hdr, err := luks2.ReadHeader(path, luks2.LockModeBlocking)
@@ -450,7 +454,9 @@ func (d *imageDeployer) run(opts *deployOptions) error {
 	d.enterScope()
 	defer d.exitScope()
 
-	d.checkPrerequisites()
+	if err := d.checkPrerequisitesBase(); err != nil {
+		return err
+	}
 
 	if opts.StandardSRKTemplate && opts.SRKTemplateUniqueData != "" {
 		return errors.New("cannot specify both --standard-srk-template and --srk-template-unique-data")
@@ -467,27 +473,12 @@ func (d *imageDeployer) run(opts *deployOptions) error {
 
 	if fi.Mode()&os.ModeDevice != 0 {
 		// Source file is a block device
-		if err := d.initDevPathFormat(opts.Positional.Input); err != nil {
-			return err
-		}
+		d.devPath = opts.Positional.Input
 		return d.deployImageOnDevice()
 	}
 
 	// Source file is not a block device
 	return d.deployImageFromFile()
-}
-
-func (d *imageDeployer) checkPrerequisites() error {
-	if d.isNbdDevice() {
-		if !nbd.IsSupported() {
-			return errors.New("cannot create nbd devices (is qemu-nbd installed?)")
-		}
-		if !nbd.IsModuleLoaded() {
-			return errors.New("cannot create nbd devices because the required kernel module is not loaded")
-		}
-	}
-
-	return nil
 }
 
 func init() {

--- a/encrypt.go
+++ b/encrypt.go
@@ -57,8 +57,6 @@ type encryptOptions struct {
 	OverrideDatasources string `long:"override-datasources" description:"Override the cloud-init datasources with the supplied comma-delimited list of sources"`
 	GrowRoot            bool   `long:"grow-root" description:"Grow the root partition to fill the available space, disabling cloud-init's cc_growpart"`
 
-	NonNbd bool `long:"non-nbd" description:"(for backward compatibilty) Indicates that the supplied block device is not a Network Block Device."`
-
 	Positional struct {
 		Input string `positional-arg-name:"Source image path (file or block device)"`
 	} `positional-args:"true" required:"true"`
@@ -188,7 +186,6 @@ type imageEncrypter struct {
 
 	opts   *encryptOptions
 	failed bool
-	isNbdInUse bool
 }
 
 func (e *imageEncrypter) maybeCopyKernelToESP() error {
@@ -492,7 +489,6 @@ func (e *imageEncrypter) setupWorkingDir() error {
 
 func (e *imageEncrypter) run(opts *encryptOptions) error {
 	e.opts = opts
-	e.isNbdInUse = !opts.NonNbd
 
 	e.enterScope()
 	defer e.exitScope()
@@ -512,13 +508,8 @@ func (e *imageEncrypter) run(opts *encryptOptions) error {
 
 	if fi.Mode()&os.ModeDevice != 0 {
 		// Input file is a block device
-		e.devPath = opts.Positional.Input
-
-		// Setting device path format depending on whether the block device is NBD or not.
-		if e.isNbdInUse {
-			e.devPathFormat = "%sp%d"
-		} else {
-			e.devPathFormat = "%s%d"
+		if err := e.initDevPathFormat(opts.Positional.Input); err != nil {
+			return err
 		}
 
 		return e.encryptImageOnDevice()

--- a/encrypt.go
+++ b/encrypt.go
@@ -493,6 +493,10 @@ func (e *imageEncrypter) run(opts *encryptOptions) error {
 	e.enterScope()
 	defer e.exitScope()
 
+	if err := e.checkPrerequisitesBase(); err != nil {
+		return err
+	}
+
 	fi, err := os.Stat(opts.Positional.Input)
 	if err != nil {
 		return xerrors.Errorf("cannot obtain source file information: %w", err)
@@ -508,10 +512,7 @@ func (e *imageEncrypter) run(opts *encryptOptions) error {
 
 	if fi.Mode()&os.ModeDevice != 0 {
 		// Input file is a block device
-		if err := e.initDevPathFormat(opts.Positional.Input); err != nil {
-			return err
-		}
-
+		e.devPath = opts.Positional.Input
 		return e.encryptImageOnDevice()
 	}
 

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -76,29 +77,37 @@ type encryptCloudImageBase struct {
 
 	workingDir string
 	devPath    string
-	devPathFormat string
 
 	partitions    gpt.Partitions
 	rootPartition *gpt.PartitionEntry
 	esp           *gpt.PartitionEntry
 }
 
-func (b *encryptCloudImageBase) initDevPathFormat(devPath string) error {
-	b.devPath = devPath
-
+func (b *encryptCloudImageBase) getDevPathFormat() (string, error) {
 	if strings.HasPrefix(b.devPath, "/dev/nbd") || strings.HasPrefix(b.devPath, "/dev/nvme") {
-		b.devPathFormat = "%sp%d"
+		return "%sp%d", nil
 	} else if strings.HasPrefix(b.devPath, "/dev/sd") || strings.HasPrefix(b.devPath, "/dev/vd") {
-		b.devPathFormat = "%s%d"
+		return "%s%d", nil
 	} else {
-		return xerrors.Errorf("Unsuppoted device path: %s. Please look at the code to deterimine what's currently supported.", devPath)
+		return "", xerrors.Errorf("Unsuppoted device path: %s. Please look at the code to deterimine what's currently supported.", b.devPath)
 	}
-
-	return nil
 }
 
 func (b *encryptCloudImageBase) isNbdDevice() bool {
 	return strings.HasPrefix(b.devPath, "/dev/nbd")
+}
+
+func (b *encryptCloudImageBase) checkPrerequisitesBase() error {
+	if b.isNbdDevice() {
+		if !nbd.IsSupported() {
+			return errors.New("cannot create nbd devices (is qemu-nbd installed?)")
+		}
+		if !nbd.IsModuleLoaded() {
+			return errors.New("cannot create nbd devices because the required kernel module is not loaded")
+		}
+	}
+
+	return nil
 }
 
 func (b *encryptCloudImageBase) workingDirPath() string {
@@ -112,14 +121,26 @@ func (b *encryptCloudImageBase) rootDevPath() string {
 	if b.rootPartition == nil {
 		log.Panicln("missing call to detectPartitions")
 	}
-	return fmt.Sprintf(b.devPathFormat, b.devPath, b.rootPartition.Index)
+
+	devPathFormat, err := b.getDevPathFormat()
+	if err != nil {
+		log.Panicln(err.Error())
+	}
+
+	return fmt.Sprintf(devPathFormat, b.devPath, b.rootPartition.Index)
 }
 
 func (b *encryptCloudImageBase) espDevPath() string {
 	if b.esp == nil {
 		log.Panicln("missing call to detectPartitions")
 	}
-	return fmt.Sprintf(b.devPathFormat, b.devPath, b.esp.Index)
+
+	devPathFormat, err := b.getDevPathFormat()
+	if err != nil {
+		log.Panicln(err.Error())
+	}
+
+	return fmt.Sprintf(devPathFormat, b.devPath, b.esp.Index)
 }
 
 func (b *encryptCloudImageBase) addCleanup(fn func() error) {

--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ const (
 )
 
 var (
+	Version             = "v1.0.1"
 	espGUID             = efi.MakeGUID(0xC12A7328, 0xF81F, 0x11D2, 0xBA4B, [...]uint8{0x00, 0xA0, 0xC9, 0x3E, 0xC9, 0x3B})
 	linuxFilesystemGUID = efi.MakeGUID(0x0FC63DAF, 0x8483, 0x4772, 0x8E79, [...]uint8{0x3D, 0x69, 0xD8, 0x47, 0x7D, 0xE4})
 )
@@ -364,6 +365,7 @@ func run(args []string) (err error) {
 }
 
 func main() {
+	log.Infoln("Version:", Version)
 	if err := run(os.Args[1:]); err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -97,14 +97,12 @@ func (b *encryptCloudImageBase) isNbdDevice() bool {
 	return strings.HasPrefix(b.devPath, "/dev/nbd")
 }
 
-func (b *encryptCloudImageBase) checkPrerequisitesBase() error {
-	if b.isNbdDevice() {
-		if !nbd.IsSupported() {
-			return errors.New("cannot create nbd devices (is qemu-nbd installed?)")
-		}
-		if !nbd.IsModuleLoaded() {
-			return errors.New("cannot create nbd devices because the required kernel module is not loaded")
-		}
+func (b *encryptCloudImageBase) checkNbdPreRequisites() error {
+	if !nbd.IsSupported() {
+		return errors.New("cannot create nbd devices (is qemu-nbd installed?)")
+	}
+	if !nbd.IsModuleLoaded() {
+		return errors.New("cannot create nbd devices because the required kernel module is not loaded")
 	}
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -83,6 +83,24 @@ type encryptCloudImageBase struct {
 	esp           *gpt.PartitionEntry
 }
 
+func (b *encryptCloudImageBase) initDevPathFormat(devPath string) error {
+	b.devPath = devPath
+
+	if strings.HasPrefix(b.devPath, "/dev/nbd") || strings.HasPrefix(b.devPath, "/dev/nvme") {
+		b.devPathFormat = "%sp%d"
+	} else if strings.HasPrefix(b.devPath, "/dev/sd") || strings.HasPrefix(b.devPath, "/dev/vd") {
+		b.devPathFormat = "%s%d"
+	} else {
+		return xerrors.Errorf("Unsuppoted device path: %s. Please look at the code to deterimine what's currently supported.", devPath)
+	}
+
+	return nil
+}
+
+func (b *encryptCloudImageBase) isNbdDevice() bool {
+	return strings.HasPrefix(b.devPath, "/dev/nbd")
+}
+
 func (b *encryptCloudImageBase) workingDirPath() string {
 	if b.workingDir == "" {
 		log.Panicln("missing call to setupWorkingDir")


### PR DESCRIPTION
On behalf of ivanp-ms, this change allows devices which are non nbd like any disk which is attached to the machine to be also provided to canonical tools for encryption.
