### PR TITLE
add github action to build and release on tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,26 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.13'
+
+      - name: Build
+        run: go build -v -o . .
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: encrypt-cloud-image


### PR DESCRIPTION
This allows a user to directly download the binary instead of building it locally.