### PR TITLE
Replace xerrors with fmt

### DIFF
--- a/create-uefi-config/main.go
+++ b/create-uefi-config/main.go
@@ -32,8 +32,6 @@ import (
 	"github.com/canonical/go-efilib"
 	"github.com/jessevdk/go-flags"
 
-	"golang.org/x/xerrors"
-
 	"github.com/canonical/encrypt-cloud-image/internal/efienv"
 )
 
@@ -75,7 +73,7 @@ func populateConfigFromVars(config *efienv.Config) error {
 	} {
 		b, _, err := efi.ReadVariable(v.name, v.guid)
 		if err != nil && err != efi.ErrVarNotExist {
-			return xerrors.Errorf("cannot read %s variable: %w", v.name, err)
+			return fmt.Errorf("cannot read %s variable: %w", v.name, err)
 		}
 
 		*v.dest = b
@@ -90,7 +88,7 @@ func populateConfigFromESLs(config *efienv.Config, path string) error {
 	switch {
 	case err != nil && os.IsNotExist(err):
 	case err != nil:
-		return xerrors.Errorf("cannot populate PK: %w", err)
+		return fmt.Errorf("cannot populate PK: %w", err)
 	default:
 		config.PK = pk
 	}
@@ -134,7 +132,7 @@ func populateConfigFromESLs(config *efienv.Config, path string) error {
 				return nil
 			}()
 			if err != nil {
-				return xerrors.Errorf("cannot populate %s: %w", d.name, err)
+				return fmt.Errorf("cannot populate %s: %w", d.name, err)
 			}
 		}
 
@@ -147,18 +145,18 @@ func populateConfigFromESLs(config *efienv.Config, path string) error {
 func run(args []string) error {
 	var options Options
 	if _, err := flags.ParseArgs(&options, args); err != nil {
-		return xerrors.Errorf("cannot parse arguments: %w", err)
+		return fmt.Errorf("cannot parse arguments: %w", err)
 	}
 
 	var config efienv.Config
 
 	if options.In != "" {
 		if err := populateConfigFromESLs(&config, options.In); err != nil {
-			return xerrors.Errorf("cannot populate config from ESLs: %w", err)
+			return fmt.Errorf("cannot populate config from ESLs: %w", err)
 		}
 	} else {
 		if err := populateConfigFromVars(&config); err != nil {
-			return xerrors.Errorf("cannot populate config from EFI variables: %w", err)
+			return fmt.Errorf("cannot populate config from EFI variables: %w", err)
 		}
 	}
 
@@ -166,14 +164,14 @@ func run(args []string) error {
 
 	f, err := os.OpenFile(options.Out, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
-		return xerrors.Errorf("cannot create file: %w", err)
+		return fmt.Errorf("cannot create file: %w", err)
 	}
 	defer f.Close()
 
 	enc := json.NewEncoder(f)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(config); err != nil {
-		return xerrors.Errorf("cannot encode config: %w", err)
+		return fmt.Errorf("cannot encode config: %w", err)
 	}
 
 	if options.SaveDatabases != "" {
@@ -199,7 +197,7 @@ func run(args []string) error {
 			},
 		} {
 			if err := ioutil.WriteFile(filepath.Join(options.SaveDatabases, d.name), d.src, 0644); err != nil {
-				return xerrors.Errorf("cannot write file %s: %w", d.name, err)
+				return fmt.Errorf("cannot write file %s: %w", d.name, err)
 			}
 		}
 	}

--- a/deploy.go
+++ b/deploy.go
@@ -38,8 +38,6 @@ import (
 	secboot_efi "github.com/snapcore/secboot/efi"
 	secboot_tpm2 "github.com/snapcore/secboot/tpm2"
 
-	"golang.org/x/xerrors"
-
 	"github.com/canonical/encrypt-cloud-image/internal/efienv"
 	"github.com/canonical/encrypt-cloud-image/internal/luks2"
 )
@@ -73,20 +71,20 @@ func readUniqueData(path string, alg tpm2.ObjectTypeId) (*tpm2.PublicIDU, error)
 
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot open file: %w", err)
+		return nil, fmt.Errorf("cannot open file: %w", err)
 	}
 
 	switch alg {
 	case tpm2.ObjectTypeRSA:
 		var rsa tpm2.PublicKeyRSA
 		if _, err := mu.UnmarshalFromReader(f, &rsa); err != nil {
-			return nil, xerrors.Errorf("cannot unmarshal unique data: %w", err)
+			return nil, fmt.Errorf("cannot unmarshal unique data: %w", err)
 		}
 		return &tpm2.PublicIDU{RSA: rsa}, nil
 	case tpm2.ObjectTypeECC:
 		var ecc *tpm2.ECCPoint
 		if _, err := mu.UnmarshalFromReader(f, &ecc); err != nil {
-			return nil, xerrors.Errorf("cannot unmarshal unique data: %w", err)
+			return nil, fmt.Errorf("cannot unmarshal unique data: %w", err)
 		}
 		return &tpm2.PublicIDU{ECC: ecc}, nil
 	}
@@ -108,7 +106,7 @@ func (d *imageDeployer) maybeAddRecoveryKey(key []byte) error {
 	log.Infoln("Adding recovery key to image")
 	b, err := ioutil.ReadFile(d.opts.RecoveryKeyFile)
 	if err != nil {
-		return xerrors.Errorf("cannot read recovery key from file: %w", err)
+		return fmt.Errorf("cannot read recovery key from file: %w", err)
 	}
 	if len(b) != 16 {
 		return errors.New("recovery key must be 16 bytes")
@@ -130,36 +128,36 @@ func (d *imageDeployer) maybeWriteCustomSRKTemplate(esp string, srkPub *tpm2.Pub
 
 	b, err := mu.MarshalToBytes(srkPub)
 	if err != nil {
-		return xerrors.Errorf("cannot marshal SRKpub: %w", err)
+		return fmt.Errorf("cannot marshal SRKpub: %w", err)
 	}
 
 	var srkTmpl *tpm2.Public
 	if _, err := mu.UnmarshalFromBytes(b, &srkTmpl); err != nil {
-		return xerrors.Errorf("cannot unmarshal SRK template: %w", err)
+		return fmt.Errorf("cannot unmarshal SRK template: %w", err)
 	}
 	srkTmpl.Unique = nil
 
 	if d.opts.SRKTemplateUniqueData != "" {
 		u, err := readUniqueData(d.opts.SRKTemplateUniqueData, srkTmpl.Type)
 		if err != nil {
-			return xerrors.Errorf("cannot read unique data: %w", err)
+			return fmt.Errorf("cannot read unique data: %w", err)
 		}
 		srkTmpl.Unique = u
 	}
 
 	b, err = mu.MarshalToBytes(srkTmpl)
 	if err != nil {
-		return xerrors.Errorf("cannot marshal SRK template: %w", err)
+		return fmt.Errorf("cannot marshal SRK template: %w", err)
 	}
 
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {
-		return xerrors.Errorf("cannot open file: %w", err)
+		return fmt.Errorf("cannot open file: %w", err)
 	}
 	defer f.Close()
 
 	if _, err := mu.MarshalToWriter(f, b); err != nil {
-		return xerrors.Errorf("cannot write SRK template to file: %w", err)
+		return fmt.Errorf("cannot write SRK template to file: %w", err)
 	}
 
 	return nil
@@ -174,12 +172,12 @@ func (d *imageDeployer) readSRKPublicArea() (*tpm2.Public, error) {
 
 	var pubBytes []byte
 	if _, err := mu.UnmarshalFromReader(f, &pubBytes); err != nil {
-		return nil, xerrors.Errorf("cannot unmarshal public area bytes: %w", err)
+		return nil, fmt.Errorf("cannot unmarshal public area bytes: %w", err)
 	}
 
 	var pub *tpm2.Public
 	if _, err := mu.UnmarshalFromBytes(pubBytes, &pub); err != nil {
-		return nil, xerrors.Errorf("cannot unmarshal public area: %w", err)
+		return nil, fmt.Errorf("cannot unmarshal public area: %w", err)
 	}
 
 	return pub, nil
@@ -192,7 +190,7 @@ func (d *imageDeployer) computePCRProtectionProfile(esp string, env secboot_efi.
 	// This function assumes that the boot architecture is Azure FDE (no grub)
 	kernelPaths, err := filepath.Glob(filepath.Join(esp, "EFI/ubuntu/kernel.efi-*"))
 	if err != nil {
-		return nil, xerrors.Errorf("cannot determine kernel paths: %w", err)
+		return nil, fmt.Errorf("cannot determine kernel paths: %w", err)
 	}
 	if _, err := os.Stat(filepath.Join(esp, "EFI/ubuntu/grubx64.efi")); err == nil {
 		// Candidate images shipped a kernel at the grub path
@@ -219,7 +217,7 @@ func (d *imageDeployer) computePCRProtectionProfile(esp string, env secboot_efi.
 			LoadSequences: []*secboot_efi.ImageLoadEvent{loadSequences},
 			Environment:   env}
 		if err := secboot_efi.AddBootManagerProfile(pcrProfile, &params); err != nil {
-			return nil, xerrors.Errorf("cannot add EFI boot manager profile: %w", err)
+			return nil, fmt.Errorf("cannot add EFI boot manager profile: %w", err)
 		}
 	}
 
@@ -230,7 +228,7 @@ func (d *imageDeployer) computePCRProtectionProfile(esp string, env secboot_efi.
 			LoadSequences: []*secboot_efi.ImageLoadEvent{loadSequences},
 			Environment:   env}
 		if err := secboot_efi.AddSecureBootPolicyProfile(pcrProfile, &params); err != nil {
-			return nil, xerrors.Errorf("cannot add EFI secure boot policy profile: %w", err)
+			return nil, fmt.Errorf("cannot add EFI secure boot policy profile: %w", err)
 		}
 	}
 
@@ -250,7 +248,7 @@ func (d *imageDeployer) computePCRProtectionProfile(esp string, env secboot_efi.
 	log.Debugln("PCR profile:", pcrProfile)
 	pcrValues, err := pcrProfile.ComputePCRValues(nil)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot compute PCR values: %w", err)
+		return nil, fmt.Errorf("cannot compute PCR values: %w", err)
 	}
 	log.Infoln("PCR values:")
 	for i, values := range pcrValues {
@@ -263,7 +261,7 @@ func (d *imageDeployer) computePCRProtectionProfile(esp string, env secboot_efi.
 	}
 	pcrs, digests, err := pcrProfile.ComputePCRDigests(nil, tpm2.HashAlgorithmSHA256)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot compute PCR digests: %w", err)
+		return nil, fmt.Errorf("cannot compute PCR digests: %w", err)
 	}
 	log.Infoln("PCR selection:", pcrs)
 	log.Infoln("PCR digests:")
@@ -281,19 +279,19 @@ func (d *imageDeployer) newEFIEnvironment() (secboot_efi.HostEnvironment, error)
 		log.Debugln("creating EFI environment from supplied az disk profile")
 		f, err := os.Open(d.opts.AzDiskProfile)
 		if err != nil {
-			return nil, xerrors.Errorf("cannot open az disk profile resource: %w", err)
+			return nil, fmt.Errorf("cannot open az disk profile resource: %w", err)
 		}
 		defer f.Close()
 
 		var profile efienv.AzDisk
 		dec := json.NewDecoder(f)
 		if err := dec.Decode(&profile); err != nil {
-			return nil, xerrors.Errorf("cannot decode az disk profile resource: %w", err)
+			return nil, fmt.Errorf("cannot decode az disk profile resource: %w", err)
 		}
 
 		env, err := efienv.NewEnvironmentFromAzDiskProfile(&profile, tcglog.AlgorithmIdList{tpm2.HashAlgorithmSHA256})
 		if err != nil {
-			return nil, xerrors.Errorf("cannot create environment from az disk profile resource: %w", err)
+			return nil, fmt.Errorf("cannot create environment from az disk profile resource: %w", err)
 		}
 
 		return env, nil
@@ -301,14 +299,14 @@ func (d *imageDeployer) newEFIEnvironment() (secboot_efi.HostEnvironment, error)
 		log.Debugln("creating EFI environment from supplied UEFI config")
 		f, err := os.Open(d.opts.UefiConfig)
 		if err != nil {
-			return nil, xerrors.Errorf("cannot open UEFI config: %w", err)
+			return nil, fmt.Errorf("cannot open UEFI config: %w", err)
 		}
 		defer f.Close()
 
 		var config efienv.Config
 		dec := json.NewDecoder(f)
 		if err := dec.Decode(&config); err != nil {
-			return nil, xerrors.Errorf("cannot decode UEFI config: %w", err)
+			return nil, fmt.Errorf("cannot decode UEFI config: %w", err)
 		}
 
 		return efienv.NewEnvironment(&config, tcglog.AlgorithmIdList{tpm2.HashAlgorithmSHA256}), nil
@@ -385,7 +383,7 @@ func (d *imageDeployer) deployImageOnDevice() error {
 
 	key, removeToken, err := d.readKeyFromImage()
 	if err != nil {
-		return xerrors.Errorf("cannot load key from LUKS2 container: %w", err)
+		return fmt.Errorf("cannot load key from LUKS2 container: %w", err)
 	}
 
 	espPath, err := d.mountESP()
@@ -395,27 +393,27 @@ func (d *imageDeployer) deployImageOnDevice() error {
 
 	efiEnv, err := d.newEFIEnvironment()
 	if err != nil {
-		return xerrors.Errorf("cannot create EFI environment for target: %w", err)
+		return fmt.Errorf("cannot create EFI environment for target: %w", err)
 	}
 
 	pcrProfile, err := d.computePCRProtectionProfile(espPath, efiEnv)
 	if err != nil {
-		return xerrors.Errorf("cannot compute PCR protection profile: %w", err)
+		return fmt.Errorf("cannot compute PCR protection profile: %w", err)
 	}
 
 	srkPub, err := d.readSRKPublicArea()
 	if err != nil {
-		return xerrors.Errorf("cannot read SRK public area: %w", err)
+		return fmt.Errorf("cannot read SRK public area: %w", err)
 	}
 	srkName, err := srkPub.Name()
 	if err != nil {
-		return xerrors.Errorf("cannot compute name of SRK: %w", err)
+		return fmt.Errorf("cannot compute name of SRK: %w", err)
 	}
 	log.Infof("supplied SRK name: %x\n", srkName)
 
 	keyDir := filepath.Join(espPath, "device/fde")
 	if err := os.MkdirAll(keyDir, 0700); err != nil {
-		return xerrors.Errorf("cannot create directory to store sealed disk unlock key: %w", err)
+		return fmt.Errorf("cannot create directory to store sealed disk unlock key: %w", err)
 	}
 
 	log.Infoln("creating importable sealed key object")
@@ -423,19 +421,19 @@ func (d *imageDeployer) deployImageOnDevice() error {
 		PCRProfile:             pcrProfile,
 		PCRPolicyCounterHandle: tpm2.HandleNull}
 	if _, err := secboot_tpm2.SealKeyToExternalTPMStorageKey(srkPub, key, filepath.Join(keyDir, "cloudimg-rootfs.sealed-key"), &params); err != nil {
-		return xerrors.Errorf("cannot seal disk unlock key: %w", err)
+		return fmt.Errorf("cannot seal disk unlock key: %w", err)
 	}
 
 	if err := d.maybeWriteCustomSRKTemplate(espPath, srkPub); err != nil {
-		return xerrors.Errorf("cannot write custom SRK template: %w", err)
+		return fmt.Errorf("cannot write custom SRK template: %w", err)
 	}
 
 	if err := d.maybeAddRecoveryKey(key); err != nil {
-		return xerrors.Errorf("cannot add recovery key: %w", err)
+		return fmt.Errorf("cannot add recovery key: %w", err)
 	}
 
 	if err := removeToken(); err != nil {
-		return xerrors.Errorf("cannot remove cleartext token from LUKS2 container: %w", err)
+		return fmt.Errorf("cannot remove cleartext token from LUKS2 container: %w", err)
 	}
 
 	return nil
@@ -465,7 +463,7 @@ func (d *imageDeployer) run(opts *deployOptions) error {
 
 	fi, err := os.Stat(opts.Positional.Input)
 	if err != nil {
-		return xerrors.Errorf("cannot obtain source file information: %w", err)
+		return fmt.Errorf("cannot obtain source file information: %w", err)
 	}
 
 	rootPartitionUUIDOverride := opts.RootPartitionUUID != ""

--- a/encrypt.go
+++ b/encrypt.go
@@ -35,8 +35,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"golang.org/x/xerrors"
-
 	internal_exec "github.com/canonical/encrypt-cloud-image/internal/exec"
 	internal_ioutil "github.com/canonical/encrypt-cloud-image/internal/ioutil"
 	"github.com/canonical/encrypt-cloud-image/internal/luks2"
@@ -146,7 +144,7 @@ func tryToOpenImageFromZip(src io.ReaderAt, sz int64) (io.ReadCloser, error) {
 	case err == zip.ErrFormat:
 		return nil, nil
 	case err != nil:
-		return nil, xerrors.Errorf("cannot read zip: %w", err)
+		return nil, fmt.Errorf("cannot read zip: %w", err)
 	}
 	log.Debugln("iterating zip archive files")
 	for _, zf := range r.File {
@@ -159,7 +157,7 @@ func tryToOpenImageFromZip(src io.ReaderAt, sz int64) (io.ReadCloser, error) {
 		log.Debugln("...found file with valid extension")
 		rc, err := zf.Open()
 		if err != nil {
-			return nil, xerrors.Errorf("cannot open image in ZIP file: %w", err)
+			return nil, fmt.Errorf("cannot open image in ZIP file: %w", err)
 		}
 		return rc, nil
 	}
@@ -172,12 +170,12 @@ func tryToOpenArchivedImage(f *os.File) (r io.ReadCloser, err error) {
 
 	fi, err := f.Stat()
 	if err != nil {
-		return nil, xerrors.Errorf("cannot obtain file info: %w", err)
+		return nil, fmt.Errorf("cannot obtain file info: %w", err)
 	}
 
 	r, err = tryToOpenImageFromZip(f, fi.Size())
 	if err != nil {
-		return nil, xerrors.Errorf("cannot find image in zip: %w", err)
+		return nil, fmt.Errorf("cannot find image in zip: %w", err)
 	}
 
 	// TODO: Try other archive formats and compression combinations
@@ -206,10 +204,10 @@ func (e *imageEncrypter) maybeCopyKernelToESP() error {
 
 	dst := filepath.Join(path, "EFI/ubuntu/grubx64.efi")
 	if err := os.Remove(dst); err != nil {
-		return xerrors.Errorf("cannot remove grub: %w", err)
+		return fmt.Errorf("cannot remove grub: %w", err)
 	}
 	if err := internal_ioutil.CopyFile(dst, e.opts.KernelEfi); err != nil {
-		return xerrors.Errorf("cannot install kernel: %w", err)
+		return fmt.Errorf("cannot install kernel: %w", err)
 	}
 
 	return nil
@@ -220,13 +218,13 @@ func (e *imageEncrypter) growRootPartition() error {
 
 	sz, err := getBlockDeviceSize(e.rootDevPath())
 	if err != nil {
-		return xerrors.Errorf("cannot determine current partition size: %w", err)
+		return fmt.Errorf("cannot determine current partition size: %w", err)
 	}
 	log.Debugln("current size:", sz)
 
 	cmd := internal_exec.LoggedCommand("growpart", e.devPath, strconv.Itoa(e.rootPartition.Index))
 	if err := cmd.Run(); err != nil {
-		return xerrors.Errorf("cannot grow partition: %w", err)
+		return fmt.Errorf("cannot grow partition: %w", err)
 	}
 
 	// XXX: This is a bit of a hack to avoid a race whilst the kernel
@@ -234,7 +232,7 @@ func (e *imageEncrypter) growRootPartition() error {
 	time.Sleep(2 * time.Second)
 	sz, err = getBlockDeviceSize(e.rootDevPath())
 	if err != nil {
-		return xerrors.Errorf("cannot determine new partition size: %w", err)
+		return fmt.Errorf("cannot determine new partition size: %w", err)
 	}
 	log.Debugln("new size:", sz)
 
@@ -246,24 +244,24 @@ func (e *imageEncrypter) encryptRootPartition() ([]byte, error) {
 
 	log.Infoln("shrinking fileystem on", devPath)
 	if err := shrinkExtFS(devPath); err != nil {
-		return nil, xerrors.Errorf("cannot shrink filesystem: %w", err)
+		return nil, fmt.Errorf("cannot shrink filesystem: %w", err)
 	}
 
 	// For tpm import sensitive data should not be larger than block size (64) else we get TPM_RC_KEY_SIZE
 	// so with two keys we need to keep key size at 16 each.
 	var key [16]byte
 	if _, err := rand.Read(key[:]); err != nil {
-		return nil, xerrors.Errorf("cannot obtain primary unlock key: %w", err)
+		return nil, fmt.Errorf("cannot obtain primary unlock key: %w", err)
 	}
 
 	log.Infoln("encrypting", devPath)
 	if err := luks2Encrypt(devPath, key[:]); err != nil {
-		return nil, xerrors.Errorf("cannot encrypt %s: %w", devPath, err)
+		return nil, fmt.Errorf("cannot encrypt %s: %w", devPath, err)
 	}
 
 	log.Infoln("setting label")
 	if err := luks2SetLabel(devPath, "cloudimg-rootfs-enc"); err != nil {
-		return nil, xerrors.Errorf("cannot set label: %w", err)
+		return nil, fmt.Errorf("cannot set label: %w", err)
 	}
 
 	token := &luks2.GenericToken{
@@ -276,7 +274,7 @@ func (e *imageEncrypter) encryptRootPartition() ([]byte, error) {
 
 	log.Infoln("importing cleartext token")
 	if err := luks2.ImportToken(devPath, token); err != nil {
-		return nil, xerrors.Errorf("cannot import token into LUKS2 container: %w", err)
+		return nil, fmt.Errorf("cannot import token into LUKS2 container: %w", err)
 	}
 
 	e.enterScope()
@@ -285,12 +283,12 @@ func (e *imageEncrypter) encryptRootPartition() ([]byte, error) {
 	volumeName := filepath.Base(devPath)
 	log.Infoln("attaching encrypted container as", volumeName)
 	if err := luks2.Activate(volumeName, devPath, key[:]); err != nil {
-		return nil, xerrors.Errorf("cannot activate LUKS container: %w", err)
+		return nil, fmt.Errorf("cannot activate LUKS container: %w", err)
 	}
 	e.addCleanup(func() error {
 		log.Infoln("detaching", volumeName)
 		if err := luks2.Deactivate(volumeName); err != nil {
-			return xerrors.Errorf("cannot detach container: %w", err)
+			return fmt.Errorf("cannot detach container: %w", err)
 		}
 		return nil
 	})
@@ -298,7 +296,7 @@ func (e *imageEncrypter) encryptRootPartition() ([]byte, error) {
 
 	log.Infoln("growing filesystem on", path)
 	if err := growExtFS(path); err != nil {
-		return nil, xerrors.Errorf("cannot grow filesystem: %w", err)
+		return nil, fmt.Errorf("cannot grow filesystem: %w", err)
 	}
 
 	return key[:], nil
@@ -317,7 +315,7 @@ func (e *imageEncrypter) customizeRootFS(growPartKey [32]byte) error {
 
 	// Disable secureboot-db.service
 	if err := os.Symlink("/dev/null", filepath.Join(path, "etc/systemd/system/secureboot-db.service")); err != nil {
-		return xerrors.Errorf("cannot disable secureboot-db.service: %w", err)
+		return fmt.Errorf("cannot disable secureboot-db.service: %w", err)
 	}
 
 	cloudCfgDir := filepath.Join(path, "etc/cloud/cloud.cfg.d")
@@ -331,7 +329,7 @@ datasource_list: [ %s ]
 		datasourceContent := fmt.Sprintf(datasourceOverrideTmpl, e.opts.OverrideDatasources)
 
 		if err := ioutil.WriteFile(filepath.Join(cloudCfgDir, "99_datasources_override.cfg"), []byte(datasourceContent), 0644); err != nil {
-			return xerrors.Errorf("cannot create datasource override file: %w", err)
+			return fmt.Errorf("cannot create datasource override file: %w", err)
 		}
 	}
 
@@ -344,7 +342,7 @@ growpart:
 `
 
 		if err := ioutil.WriteFile(filepath.Join(cloudCfgDir, "99_disable_growpart.cfg"), []byte(disableGrowPart), 0644); err != nil {
-			return xerrors.Errorf("cannot create growpart override file: %w", err)
+			return fmt.Errorf("cannot create growpart override file: %w", err)
 		}
 	} else {
 		log.Debugln("writing key data for cloud-init cc_growpart")
@@ -354,11 +352,11 @@ growpart:
 			Slot: luks2GrowPartKeyslot}
 		b, err := json.Marshal(&data)
 		if err != nil {
-			return xerrors.Errorf("cannot marshal key data for growpart: %w", err)
+			return fmt.Errorf("cannot marshal key data for growpart: %w", err)
 		}
 
 		if err := ioutil.WriteFile(filepath.Join(path, "cc_growpart_keydata"), b, 0600); err != nil {
-			return xerrors.Errorf("cannot write key data for growpart: %w", err)
+			return fmt.Errorf("cannot write key data for growpart: %w", err)
 		}
 	}
 
@@ -379,17 +377,17 @@ func (e *imageEncrypter) encryptImageOnDevice() error {
 	var growPartKey [32]byte
 	if !e.opts.GrowRoot {
 		if _, err := rand.Read(growPartKey[:]); err != nil {
-			return xerrors.Errorf("cannot obtain key for cc_growpart: %w", err)
+			return fmt.Errorf("cannot obtain key for cc_growpart: %w", err)
 		}
 	}
 
 	if err := e.customizeRootFS(growPartKey); err != nil {
-		return xerrors.Errorf("cannot apply customizations to root filesystem: %w", err)
+		return fmt.Errorf("cannot apply customizations to root filesystem: %w", err)
 	}
 
 	key, err := e.encryptRootPartition()
 	if err != nil {
-		return xerrors.Errorf("cannot encrypt root partition: %w", err)
+		return fmt.Errorf("cannot encrypt root partition: %w", err)
 	}
 
 	if !e.opts.GrowRoot {
@@ -399,14 +397,14 @@ func (e *imageEncrypter) encryptImageOnDevice() error {
 				ForceIterations: 4},
 			Slot: luks2GrowPartKeyslot}
 		if err := luks2.AddKey(e.rootDevPath(), key, growPartKey[:], &opts); err != nil {
-			return xerrors.Errorf("cannot add key to container for cc_growpart: %w", err)
+			return fmt.Errorf("cannot add key to container for cc_growpart: %w", err)
 		}
 	} else if err := e.growRootPartition(); err != nil {
-		return xerrors.Errorf("cannot grow root partition: %w", err)
+		return fmt.Errorf("cannot grow root partition: %w", err)
 	}
 
 	if err := e.maybeCopyKernelToESP(); err != nil {
-		return xerrors.Errorf("cannot copy kernel image to ESP: %w", err)
+		return fmt.Errorf("cannot copy kernel image to ESP: %w", err)
 	}
 
 	return nil
@@ -415,7 +413,7 @@ func (e *imageEncrypter) encryptImageOnDevice() error {
 func (e *imageEncrypter) prepareWorkingImage() (string, error) {
 	f, err := os.Open(e.opts.Positional.Input)
 	if err != nil {
-		return "", xerrors.Errorf("cannot open source image: %w", err)
+		return "", fmt.Errorf("cannot open source image: %w", err)
 	}
 	defer func() {
 		if err := f.Close(); err != nil {
@@ -426,7 +424,7 @@ func (e *imageEncrypter) prepareWorkingImage() (string, error) {
 	r, err := tryToOpenArchivedImage(f)
 	switch {
 	case err != nil:
-		return "", xerrors.Errorf("cannot open archived source image: %w", err)
+		return "", fmt.Errorf("cannot open archived source image: %w", err)
 	case r != nil:
 		// Input file is an archive with a valid image
 		defer func() {
@@ -448,7 +446,7 @@ func (e *imageEncrypter) prepareWorkingImage() (string, error) {
 	path := filepath.Join(e.workingDirPath(), filepath.Base(e.opts.Output))
 	log.Infoln("making copy of source image to", path)
 	if err := internal_ioutil.CopyFromReaderToFile(path, r); err != nil {
-		return "", xerrors.Errorf("cannot make working copy of source image: %w", err)
+		return "", fmt.Errorf("cannot make working copy of source image: %w", err)
 	}
 
 	return path, nil
@@ -458,7 +456,7 @@ func (e *imageEncrypter) encryptImageFromFile() error {
 	path, err := e.prepareWorkingImage()
 	switch {
 	case err != nil:
-		return xerrors.Errorf("cannot prepare working image: %w", err)
+		return fmt.Errorf("cannot prepare working image: %w", err)
 	case path != "":
 		// We aren't encrypting the source image
 		e.addCleanup(func() error {
@@ -466,7 +464,7 @@ func (e *imageEncrypter) encryptImageFromFile() error {
 				return nil
 			}
 			if err := os.Rename(path, e.opts.Output); err != nil {
-				return xerrors.Errorf("cannot move working image to final path: %w", err)
+				return fmt.Errorf("cannot move working image to final path: %w", err)
 			}
 			return nil
 		})
@@ -498,7 +496,7 @@ func (e *imageEncrypter) run(opts *encryptOptions) error {
 
 	fi, err := os.Stat(opts.Positional.Input)
 	if err != nil {
-		return xerrors.Errorf("cannot obtain source file information: %w", err)
+		return fmt.Errorf("cannot obtain source file information: %w", err)
 	}
 
 	if opts.Output != "" && fi.Mode()&os.ModeDevice != 0 {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/snapcore/secboot v0.0.0-20240411101434-f3ad7c92552a
 	github.com/snapcore/snapd v0.0.0-20240321202327-b749eda44d9f
 	golang.org/x/sys v0.7.0
-	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 )
 
@@ -26,6 +25,7 @@ require (
 	go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1 // indirect
 	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 // indirect
 	golang.org/x/net v0.9.0 // indirect
+	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect
 	gopkg.in/retry.v1 v1.0.3 // indirect
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/internal/efienv/az.go
+++ b/internal/efienv/az.go
@@ -27,8 +27,6 @@ import (
 	"github.com/canonical/go-efilib"
 	"github.com/canonical/tcglog-parser"
 	secboot_efi "github.com/snapcore/secboot/efi"
-
-	"golang.org/x/xerrors"
 )
 
 var (
@@ -140,12 +138,12 @@ func newConfigFromAzDiskProfile(profile *AzDisk) (*Config, error) {
 	} {
 		decoded, err := decodeAzSignatureDb(db.src)
 		if err != nil {
-			return nil, xerrors.Errorf("cannot decode %s: %w", db.name, err)
+			return nil, fmt.Errorf("cannot decode %s: %w", db.name, err)
 		}
 
 		encoded := new(bytes.Buffer)
 		if err := decoded.Write(encoded); err != nil {
-			return nil, xerrors.Errorf("cannot encode %s: %w", db.name, err)
+			return nil, fmt.Errorf("cannot encode %s: %w", db.name, err)
 		}
 
 		*db.dst = encoded.Bytes()

--- a/internal/efienv/create-test-az-model/main.go
+++ b/internal/efienv/create-test-az-model/main.go
@@ -30,8 +30,6 @@ import (
 	"github.com/canonical/go-efilib"
 	log "github.com/sirupsen/logrus"
 
-	"golang.org/x/xerrors"
-
 	"github.com/canonical/encrypt-cloud-image/internal/efienv"
 )
 
@@ -76,14 +74,14 @@ func run(args []string) error {
 
 	f, err := os.Open(input)
 	if err != nil {
-		return xerrors.Errorf("cannot open file: %w", err)
+		return fmt.Errorf("cannot open file: %w", err)
 	}
 	defer f.Close()
 
 	var config efienv.Config
 	dec := json.NewDecoder(f)
 	if err := dec.Decode(&config); err != nil {
-		return xerrors.Errorf("cannot decode config: %w", err)
+		return fmt.Errorf("cannot decode config: %w", err)
 	}
 
 	profile := efienv.AzDisk{
@@ -98,11 +96,11 @@ func run(args []string) error {
 	switch {
 	case err != nil && err == io.EOF:
 	case err != nil:
-		return xerrors.Errorf("cannot read PK: %w", err)
+		return fmt.Errorf("cannot read PK: %w", err)
 	default:
 		azdb, err := encodeAzSignatureDb(efi.SignatureDatabase{l})
 		if err != nil {
-			return xerrors.Errorf("cannot encode PK to az format: %w", err)
+			return fmt.Errorf("cannot encode PK to az format: %w", err)
 		}
 		profile.Properties.UefiSettings.Signatures.PK = azdb[0]
 	}
@@ -131,12 +129,12 @@ func run(args []string) error {
 		r := bytes.NewReader(d.src)
 		db, err := efi.ReadSignatureDatabase(r)
 		if err != nil {
-			return xerrors.Errorf("cannot read %s: %w", d.name, err)
+			return fmt.Errorf("cannot read %s: %w", d.name, err)
 		}
 
 		azdb, err := encodeAzSignatureDb(db)
 		if err != nil {
-			return xerrors.Errorf("cannot encode %s to az format: %w", d.name, err)
+			return fmt.Errorf("cannot encode %s to az format: %w", d.name, err)
 		}
 
 		*d.dst = azdb
@@ -144,7 +142,7 @@ func run(args []string) error {
 
 	f, err = os.OpenFile(output, os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
-		return xerrors.Errorf("cannot create az template file: %w", err)
+		return fmt.Errorf("cannot create az template file: %w", err)
 	}
 	defer f.Close()
 

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -30,8 +30,6 @@ import (
 	"sync"
 
 	log "github.com/sirupsen/logrus"
-
-	"golang.org/x/xerrors"
 )
 
 type teeReadCloser struct {
@@ -142,7 +140,7 @@ func (c *LoggedCmd) Start() error {
 		}
 
 		err := scanner.Err()
-		if xerrors.Is(err, os.ErrClosed) {
+		if errors.Is(err, os.ErrClosed) {
 			err = nil
 		}
 
@@ -159,7 +157,7 @@ func (c *LoggedCmd) Start() error {
 	if c.Cmd.Stdout == nil {
 		stdout, err := c.Cmd.StdoutPipe()
 		if err != nil {
-			return xerrors.Errorf("cannot obtain stdout pipe: %w", err)
+			return fmt.Errorf("cannot obtain stdout pipe: %w", err)
 		}
 		c.closeAfterStartError = append(c.closeAfterStartError, stdout)
 
@@ -175,7 +173,7 @@ func (c *LoggedCmd) Start() error {
 		stderr, err := c.Cmd.StderrPipe()
 		if err != nil {
 			c.closeHandles(c.closeAfterStartError)
-			return xerrors.Errorf("cannot obtain stderr pipe: %w", err)
+			return fmt.Errorf("cannot obtain stderr pipe: %w", err)
 		}
 
 		if c.Stderr != nil {

--- a/internal/gpt/gpt.go
+++ b/internal/gpt/gpt.go
@@ -2,13 +2,12 @@ package gpt
 
 import (
 	"encoding/binary"
+	"fmt"
 	"errors"
 	"io"
 	"os"
 
 	"github.com/canonical/go-efilib"
-
-	"golang.org/x/xerrors"
 )
 
 const (
@@ -69,7 +68,7 @@ func (partitions Partitions) FindByPartitionType(t efi.GUID) *PartitionEntry {
 func ReadPartitionTable(path string) (Partitions, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot open file: %w", err)
+		return nil, fmt.Errorf("cannot open file: %w", err)
 	}
 
 	var mbr mbr
@@ -93,13 +92,13 @@ func ReadPartitionTable(path string) (Partitions, error) {
 
 	hdr, err := efi.ReadPartitionTableHeader(io.NewSectionReader(f, blockSize, blockSize), false)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot read GPT header: %w", err)
+		return nil, fmt.Errorf("cannot read GPT header: %w", err)
 	}
 
 	entReader := io.NewSectionReader(f, blockSize*2, int64(hdr.NumberOfPartitionEntries*hdr.SizeOfPartitionEntry))
 	entries, err := efi.ReadPartitionEntries(entReader, hdr.NumberOfPartitionEntries, hdr.SizeOfPartitionEntry)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot read partition entries: %w", err)
+		return nil, fmt.Errorf("cannot read partition entries: %w", err)
 	}
 
 	var partitions Partitions

--- a/internal/ioutil/ioutil.go
+++ b/internal/ioutil/ioutil.go
@@ -20,16 +20,15 @@
 package ioutil
 
 import (
+	"fmt"
 	"io"
 	"os"
-
-	"golang.org/x/xerrors"
 )
 
 func CopyFromReaderToFile(dst string, src io.Reader) error {
 	f, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
 	if err != nil {
-		return xerrors.Errorf("cannot open file: %w", err)
+		return fmt.Errorf("cannot open file: %w", err)
 	}
 	defer f.Close()
 
@@ -40,7 +39,7 @@ func CopyFromReaderToFile(dst string, src io.Reader) error {
 func CopyFile(dst, src string) error {
 	f, err := os.Open(src)
 	if err != nil {
-		return xerrors.Errorf("cannot open file: %w", err)
+		return fmt.Errorf("cannot open file: %w", err)
 	}
 	defer f.Close()
 

--- a/internal/luks2/cryptsetup.go
+++ b/internal/luks2/cryptsetup.go
@@ -30,8 +30,6 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/osutil"
-
-	"golang.org/x/xerrors"
 )
 
 const (
@@ -56,7 +54,7 @@ func cryptsetupCmd(stdin io.Reader, callback func(cmd *exec.Cmd) error, args ...
 	cmd.Stderr = &b
 
 	if err := cmd.Start(); err != nil {
-		return xerrors.Errorf("cannot start cryptsetup: %w", err)
+		return fmt.Errorf("cannot start cryptsetup: %w", err)
 	}
 
 	var cbErr error
@@ -216,7 +214,7 @@ func AddKey(devicePath string, existingKey, key []byte, options *AddKeyOptions) 
 
 	fifoPath, cleanupFifo, err := mkFifo()
 	if err != nil {
-		return xerrors.Errorf("cannot create FIFO for passing existing key to cryptsetup: %w", err)
+		return fmt.Errorf("cannot create FIFO for passing existing key to cryptsetup: %w", err)
 	}
 	defer cleanupFifo()
 
@@ -250,7 +248,7 @@ func AddKey(devicePath string, existingKey, key []byte, options *AddKeyOptions) 
 			// If we fail to open the write end, the read end will be blocked in open(), so
 			// kill the process.
 			cmd.Process.Kill()
-			return xerrors.Errorf("cannot open FIFO for passing existing key to cryptsetup: %w", err)
+			return fmt.Errorf("cannot open FIFO for passing existing key to cryptsetup: %w", err)
 		}
 
 		if _, err := f.Write(existingKey); err != nil {
@@ -261,14 +259,14 @@ func AddKey(devicePath string, existingKey, key []byte, options *AddKeyOptions) 
 				// so kill the process.
 				cmd.Process.Kill()
 			}
-			return xerrors.Errorf("cannot pass existing key to cryptsetup: %w", err)
+			return fmt.Errorf("cannot pass existing key to cryptsetup: %w", err)
 		}
 
 		if err := f.Close(); err != nil {
 			// If we can't close the write end, the read end will remain blocked inside read(),
 			// so kill the process.
 			cmd.Process.Kill()
-			return xerrors.Errorf("cannot close write end of FIFO: %w", err)
+			return fmt.Errorf("cannot close write end of FIFO: %w", err)
 		}
 
 		return nil
@@ -281,7 +279,7 @@ func AddKey(devicePath string, existingKey, key []byte, options *AddKeyOptions) 
 func ImportToken(devicePath string, token Token) error {
 	tokenJSON, err := json.Marshal(token)
 	if err != nil {
-		return xerrors.Errorf("cannot serialize token: %w", err)
+		return fmt.Errorf("cannot serialize token: %w", err)
 	}
 
 	return cryptsetupCmd(bytes.NewReader(tokenJSON), nil, "token", "import", devicePath)

--- a/internal/luks2/fifo.go
+++ b/internal/luks2/fifo.go
@@ -26,7 +26,6 @@ import (
 	"path/filepath"
 
 	"golang.org/x/sys/unix"
-	"golang.org/x/xerrors"
 )
 
 func mkFifo() (string, func(), error) {
@@ -35,7 +34,7 @@ func mkFifo() (string, func(), error) {
 	// process reaches here at the same time.
 	dir, err := ioutil.TempDir("/run", filepath.Base(os.Args[0])+".")
 	if err != nil {
-		return "", nil, xerrors.Errorf("cannot create temporary directory: %w", err)
+		return "", nil, fmt.Errorf("cannot create temporary directory: %w", err)
 	}
 
 	cleanup := func() {
@@ -54,7 +53,7 @@ func mkFifo() (string, func(), error) {
 
 	fifo := filepath.Join(dir, "fifo")
 	if err := unix.Mkfifo(fifo, 0600); err != nil {
-		return "", nil, xerrors.Errorf("cannot create FIFO: %w", err)
+		return "", nil, fmt.Errorf("cannot create FIFO: %w", err)
 	}
 
 	succeeded = true

--- a/internal/nbd/nbd.go
+++ b/internal/nbd/nbd.go
@@ -36,8 +36,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"golang.org/x/xerrors"
-
 	internal_exec "github.com/canonical/encrypt-cloud-image/internal/exec"
 )
 
@@ -247,7 +245,7 @@ func (c *Connection) tryConnectToDevice(dev nbdDev) (err error) {
 	}
 
 	if err := udevadmCmd.Start(); err != nil {
-		return xerrors.Errorf("cannot start udevadm monitor: %w", err)
+		return fmt.Errorf("cannot start udevadm monitor: %w", err)
 	}
 
 	c.logger.Debugln("started udevadm monitor")
@@ -314,7 +312,7 @@ func (c *Connection) tryConnectToDevice(dev nbdDev) (err error) {
 			p, _ := os.FindProcess(pid)
 			if err := p.Kill(); err != nil {
 				var e syscall.Errno
-				if xerrors.As(err, &e) {
+				if errors.As(err, &e) {
 					log.WithError(err).Panicln("cannot kill qemu-nbd")
 				}
 			}
@@ -326,16 +324,16 @@ func (c *Connection) tryConnectToDevice(dev nbdDev) (err error) {
 		case err := <-c.qemuNbdDone:
 			c.logger.Debugln("qemu-nbd exitted with an error:", err)
 			var e *exec.ExitError
-			if xerrors.As(err, &e) && e.ExitCode() == 1 {
+			if errors.As(err, &e) && e.ExitCode() == 1 {
 				return errDeviceBusy
 			}
-			return xerrors.Errorf("qemu-nbd failed: %w", err)
+			return fmt.Errorf("qemu-nbd failed: %w", err)
 		case pid = <-qemuNbdStarted:
 			c.logger.Debugln("qemu-nbd started with PID:", pid)
 			managed, err := dev.isManagedByProcess(pid)
 			switch {
 			case err != nil:
-				return xerrors.Errorf("cannot determine if %s is managed by us: %w", dev, err)
+				return fmt.Errorf("cannot determine if %s is managed by us: %w", dev, err)
 			case managed:
 				c.logger.Debugln("our qemu-nbd manages the NBD device")
 				return nil
@@ -348,7 +346,7 @@ func (c *Connection) tryConnectToDevice(dev nbdDev) (err error) {
 				managed, err := dev.isManagedByProcess(pid)
 				switch {
 				case err != nil:
-					return xerrors.Errorf("cannot determine if %s is managed by us: %w", dev, err)
+					return fmt.Errorf("cannot determine if %s is managed by us: %w", dev, err)
 				case managed:
 					c.logger.Debugln("our qemu-nbd manages the NBD device")
 					return nil
@@ -359,7 +357,7 @@ func (c *Connection) tryConnectToDevice(dev nbdDev) (err error) {
 				c.logger.Debugln("we haven't got the PID for qemu-nbd yet")
 			}
 		case err := <-monitorDone:
-			return xerrors.Errorf("udevadm monitor scanner goroutine returned unexpectedly: %w", err)
+			return fmt.Errorf("udevadm monitor scanner goroutine returned unexpectedly: %w", err)
 		}
 	}
 }
@@ -367,7 +365,7 @@ func (c *Connection) tryConnectToDevice(dev nbdDev) (err error) {
 func (c *Connection) connect() error {
 	maxDevices, err := getMaxNBDs()
 	if err != nil {
-		return xerrors.Errorf("cannot determine maximum number of NBD devices: %w", err)
+		return fmt.Errorf("cannot determine maximum number of NBD devices: %w", err)
 	}
 	c.logger.Debugln("maximum number of NBD devices:", maxDevices)
 
@@ -379,7 +377,7 @@ func (c *Connection) connect() error {
 			case err == errDeviceBusy:
 				c.logger.Debugln("device", j, "is already managed by another process")
 			case err != nil:
-				return xerrors.Errorf("unexpected error when trying %s: %w", j, err)
+				return fmt.Errorf("unexpected error when trying %d: %w", j, err)
 			default:
 				c.logger.Debugln("connected to device", j)
 				c.dev = nbdDev(j)
@@ -430,7 +428,7 @@ func ConnectImage(path string) (conn *Connection, err error) {
 			if entry, ok := v.(*log.Entry); ok {
 				if e, ok := entry.Data[log.ErrorKey]; ok {
 					var s syscall.Errno
-					if xerrors.As(e.(error), &s) {
+					if errors.As(e.(error), &s) {
 						err = e.(error)
 						return
 					}

--- a/main.go
+++ b/main.go
@@ -33,8 +33,6 @@ import (
 	"github.com/jessevdk/go-flags"
 	log "github.com/sirupsen/logrus"
 
-	"golang.org/x/xerrors"
-
 	internal_exec "github.com/canonical/encrypt-cloud-image/internal/exec"
 	"github.com/canonical/encrypt-cloud-image/internal/gpt"
 	"github.com/canonical/encrypt-cloud-image/internal/logutil"
@@ -90,7 +88,7 @@ func (b *encryptCloudImageBase) getDevPathFormat() (string, error) {
 	} else if strings.HasPrefix(b.devPath, "/dev/sd") || strings.HasPrefix(b.devPath, "/dev/vd") {
 		return "%s%d", nil
 	} else {
-		return "", xerrors.Errorf("Unsupported device path: %s. Please look at the code to determine what is currently supported.", b.devPath)
+		return "", fmt.Errorf("Unsupported device path: %s. Please look at the code to determine what is currently supported.", b.devPath)
 	}
 }
 
@@ -180,7 +178,7 @@ func (b *encryptCloudImageBase) exitScope() {
 func (b *encryptCloudImageBase) setupWorkingDir(baseDir string) error {
 	name, err := ioutil.TempDir(baseDir, "encrypt-cloud-image.")
 	if err != nil {
-		return xerrors.Errorf("cannot setup working directory: %w", err)
+		return fmt.Errorf("cannot setup working directory: %w", err)
 	}
 	b.workingDir = name
 	log.Infoln("temporary working directory:", name)
@@ -188,7 +186,7 @@ func (b *encryptCloudImageBase) setupWorkingDir(baseDir string) error {
 	b.addCleanup(func() error {
 		log.Debugln("removing", name)
 		if err := os.RemoveAll(name); err != nil {
-			return xerrors.Errorf("cannot remove working directory: %w", err)
+			return fmt.Errorf("cannot remove working directory: %w", err)
 		}
 		return nil
 	})
@@ -199,7 +197,7 @@ func (b *encryptCloudImageBase) setupWorkingDir(baseDir string) error {
 func (b *encryptCloudImageBase) connectNbd(path string) error {
 	conn, err := nbd.ConnectImage(path)
 	if err != nil {
-		return xerrors.Errorf("cannot connect %s to NBD device: %w", path, err)
+		return fmt.Errorf("cannot connect %s to NBD device: %w", path, err)
 	}
 	b.devPath = conn.DevPath()
 	log.Infoln("connected", path, "to", conn.DevPath())
@@ -207,7 +205,7 @@ func (b *encryptCloudImageBase) connectNbd(path string) error {
 	b.addCleanup(func() error {
 		log.Debugln("disconnecting", conn.DevPath())
 		if err := conn.Disconnect(); err != nil {
-			return xerrors.Errorf("cannot disconnect from %s: %w", conn.DevPath(), err)
+			return fmt.Errorf("cannot disconnect from %s: %w", conn.DevPath(), err)
 		}
 		return nil
 	})
@@ -218,7 +216,7 @@ func (b *encryptCloudImageBase) connectNbd(path string) error {
 func (b *encryptCloudImageBase) detectPartitions(rootPartitionUUID string, espPartitionUUID string) error {
 	partitions, err := gpt.ReadPartitionTable(b.devPath)
 	if err != nil {
-		return xerrors.Errorf("cannot read partition table from %s: %w", b.devPath, err)
+		return fmt.Errorf("cannot read partition table from %s: %w", b.devPath, err)
 	}
 	b.partitions = partitions
 	log.Debugln("partition table for", b.devPath, ":", partitions)
@@ -268,7 +266,7 @@ func (b *encryptCloudImageBase) mount(devPath, mountPath, fs string) error {
 
 	b.addCleanup(func() error {
 		if err := unmount(); err != nil {
-			return xerrors.Errorf("cannot unmount %s: %w", mountPath, err)
+			return fmt.Errorf("cannot unmount %s: %w", mountPath, err)
 		}
 		return nil
 	})
@@ -279,13 +277,13 @@ func (b *encryptCloudImageBase) mount(devPath, mountPath, fs string) error {
 func (b *encryptCloudImageBase) mountRoot() (path string, err error) {
 	path = filepath.Join(b.workingDirPath(), "rootfs")
 	if err := os.MkdirAll(path, 0700); err != nil {
-		return "", xerrors.Errorf("cannot create directory to mount rootfs: %w", err)
+		return "", fmt.Errorf("cannot create directory to mount rootfs: %w", err)
 	}
 
 	log.Infoln("mounting root filesystem to", path)
 
 	if err := b.mount(b.rootDevPath(), path, "ext4"); err != nil {
-		return "", xerrors.Errorf("cannot mount rootfs: %w", err)
+		return "", fmt.Errorf("cannot mount rootfs: %w", err)
 	}
 
 	return path, nil
@@ -294,13 +292,13 @@ func (b *encryptCloudImageBase) mountRoot() (path string, err error) {
 func (b *encryptCloudImageBase) mountESP() (path string, err error) {
 	path = filepath.Join(b.workingDirPath(), "esp")
 	if err := os.MkdirAll(path, 0700); err != nil {
-		return "", xerrors.Errorf("cannot create directory to mount ESP: %w", err)
+		return "", fmt.Errorf("cannot create directory to mount ESP: %w", err)
 	}
 
 	log.Infoln("mounting ESP to", path)
 
 	if err := b.mount(b.espDevPath(), path, "vfat"); err != nil {
-		return "", xerrors.Errorf("cannot mount ESP: %w", err)
+		return "", fmt.Errorf("cannot mount ESP: %w", err)
 	}
 
 	return path, nil


### PR DESCRIPTION
Proposal to fix issue https://github.com/canonical/encrypt-cloud-image/issues/24
Features that are not standard in fmt package but available in xerrors package are being imported from the errors package.

The xerror package is deprecated and replaced with fmt and errors.