### PR TITLE
add new integrity-protect command

### DIFF
--- a/integrity.go
+++ b/integrity.go
@@ -1,0 +1,294 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	internal_exec "github.com/canonical/encrypt-cloud-image/internal/exec"
+	"github.com/canonical/encrypt-cloud-image/internal/gpt"
+	internal_ioutil "github.com/canonical/encrypt-cloud-image/internal/ioutil"
+	log "github.com/sirupsen/logrus"
+
+	snapd_dmverity "github.com/snapcore/snapd/snap/integrity/dmverity"
+	"golang.org/x/xerrors"
+)
+
+const (
+	verityPartitionNum = 13
+)
+
+type integrityOptions struct {
+	Output string `short:"o" long:"output" description:"Output image path"`
+
+	Positional struct {
+		Input string `positional-arg-name:"Source image path (file or block device)"`
+	} `positional-args:"true" required:"true"`
+}
+
+func (o *integrityOptions) Execute(_ []string) error {
+	d := new(imageIntegrityProtector)
+	return d.run(o)
+}
+
+type imageIntegrityProtector struct {
+	encryptCloudImageBase
+
+	opts            *integrityOptions
+	failed          bool
+	verityPartition *gpt.PartitionEntry
+}
+
+func (i *imageIntegrityProtector) createIntegrityDataForRootPartition() (string, string, error) {
+	devPath := i.rootDevPath()
+
+	verityFilePath := filepath.Join(i.workingDirPath(), "rootfs.verity")
+
+	// Run fsck on root partition before calculating verity data
+	cmd := internal_exec.LoggedCommand("fsck", "-p", devPath)
+
+	if err := cmd.Run(); err != nil {
+		return "", "", err
+	}
+
+	log.Infoln("generating verity data for root partition")
+	verityInfo, err := snapd_dmverity.Format(devPath, verityFilePath)
+	if err != nil {
+		return "", "", err
+	}
+
+	return verityInfo.RootHash, verityFilePath, nil
+}
+
+func (i *imageIntegrityProtector) updateVerityPartition(verityFilePath string) error {
+	log.Infoln("updating verity partition ", i.verityDevPath())
+
+	// XXX: this is a hack that populates the verity partition index which is used
+	// by verityDevPath() in the dd command below. This is needed as the new
+	// partition cannot be discovered unless the disk is remounted.
+	i.verity = &gpt.PartitionEntry{
+		Index: verityPartitionNum,
+	}
+
+	cmd := internal_exec.LoggedCommand("dd",
+		"if="+verityFilePath,
+		"of="+i.verityDevPath(),
+	)
+
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// These match the structs in snap-bootstrap
+type ImageManifestPartition struct {
+	FsLabel  string `json:"label"`
+	RootHash string `json:"root_hash"`
+	Overlay  string `json:"overlay"`
+}
+
+type ImageManifest struct {
+	Partitions []ImageManifestPartition `json:"partitions"`
+}
+
+func (i *imageIntegrityProtector) integrityProtectImageOnDevice() error {
+	if i.devPath == "" {
+		panic("no device path")
+	}
+
+	i.enterScope()
+	defer i.exitScope()
+
+	if err := i.detectPartitions(); err != nil {
+		return err
+	}
+
+	rootHash, verityFilePath, err := i.createIntegrityDataForRootPartition()
+	if err != nil {
+		return err
+	}
+
+	log.Infoln("dm-verity root hash for the root partition: ", rootHash)
+
+	err = i.updateVerityPartition(verityFilePath)
+	if err != nil {
+		return err
+	}
+
+	log.Infoln("generating manifest with integrity information for image on", i.devPath)
+
+	partition := ImageManifestPartition{
+		FsLabel:  "cloudimg-rootfs",
+		RootHash: rootHash,
+		Overlay:  "lowerdir",
+	}
+
+	im := &ImageManifest{
+		Partitions: []ImageManifestPartition{partition},
+	}
+
+	imJson, err := json.Marshal(im)
+	if err != nil {
+		return err
+	}
+
+	espPath, err := i.mountESP()
+	if err != nil {
+		return err
+	}
+
+	ukiRootPath := filepath.Join(espPath, "EFI/ubuntu")
+	log.Infoln("creating manifest under", ukiRootPath)
+
+	if err := os.WriteFile(filepath.Join(ukiRootPath, "manifest.json"), imJson, 0644); err != nil {
+		return xerrors.Errorf("cannot create manifest file: %w", err)
+	}
+
+	return nil
+}
+
+func (i *imageIntegrityProtector) prepareWorkingImage() (string, error) {
+	f, err := os.Open(i.opts.Positional.Input)
+	if err != nil {
+		return "", xerrors.Errorf("cannot open source image: %w", err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			log.WithError(err).Warningln("cannot close source image")
+		}
+	}()
+
+	r, err := tryToOpenArchivedImage(f)
+	switch {
+	case err != nil:
+		return "", xerrors.Errorf("cannot open archived source image: %w", err)
+	case r != nil:
+		// Input file is an archive with a valid image
+		defer func() {
+			if err := r.Close(); err != nil {
+				log.WithError(err).Warningln("cannot close unpacked source image")
+			}
+		}()
+		if i.opts.Output == "" {
+			return "", errors.New("must specify --ouptut if the supplied input source is an archive")
+		}
+	case i.opts.Output != "":
+		// Input file is not an archive and we are not encrypting the source image
+		r = f
+	default:
+		// Input file is not an archive and we are encrypting the source image
+		return "", nil
+	}
+
+	path := filepath.Join(i.workingDirPath(), filepath.Base(i.opts.Output))
+	log.Infoln("making copy of source image to", path)
+	if err := internal_ioutil.CopyFromReaderToFile(path, r); err != nil {
+		return "", xerrors.Errorf("cannot make working copy of source image: %w", err)
+	}
+
+	return path, nil
+}
+
+func (i *imageIntegrityProtector) integrityProtectImageFromFile() error {
+	path, err := i.prepareWorkingImage()
+	switch {
+	case err != nil:
+		return xerrors.Errorf("cannot prepare working image: %w", err)
+	case path != "":
+		// We aren't encrypting the source image
+		i.addCleanup(func() error {
+			if i.failed {
+				return nil
+			}
+			if err := os.Rename(path, i.opts.Output); err != nil {
+				return xerrors.Errorf("cannot move working image to final path: %w", err)
+			}
+			return nil
+		})
+	default:
+		// We are encrypting the source image
+		path = i.opts.Positional.Input
+	}
+
+	if err := i.connectNbd(path); err != nil {
+		return err
+	}
+
+	return i.integrityProtectImageOnDevice()
+}
+
+func (i *imageIntegrityProtector) setupWorkingDir() error {
+	var baseDir string
+	if i.opts.Output != "" {
+		baseDir = filepath.Dir(i.opts.Output)
+	}
+	return i.encryptCloudImageBase.setupWorkingDir(baseDir)
+}
+
+func (i *imageIntegrityProtector) run(opts *integrityOptions) error {
+	i.opts = opts
+
+	i.enterScope()
+	defer i.exitScope()
+
+	fi, err := os.Stat(opts.Positional.Input)
+	if err != nil {
+		return xerrors.Errorf("cannot obtain source file information: %w", err)
+	}
+
+	if opts.Output != "" && fi.Mode()&os.ModeDevice != 0 {
+		return errors.New("cannot specify --output with a block device")
+	}
+
+	if err := i.setupWorkingDir(); err != nil {
+		return err
+	}
+
+	if fi.Mode()&os.ModeDevice != 0 {
+		// Source file is a block device
+		i.devPath = opts.Positional.Input
+		if i.isNbdDevice() {
+			if err := i.checkNbdPreRequisites(); err != nil {
+				return err
+			}
+		}
+
+		return i.integrityProtectImageOnDevice()
+	}
+
+	// Source file is not a block device
+	if err := i.checkNbdPreRequisites(); err != nil {
+		return err
+	}
+
+	return i.integrityProtectImageFromFile()
+}
+
+func init() {
+	if _, err := parser.AddCommand("integrity-protect", "Generate dm-verity data for the root fs partition and a configurationo manifest", "", &integrityOptions{}); err != nil {
+		log.WithError(err).Panicln("cannot add verity command")
+	}
+}

--- a/integrity.go
+++ b/integrity.go
@@ -322,12 +322,12 @@ func (i *imageIntegrityProtector) run(opts *integrityOptions) error {
 	i.enterScope()
 	defer i.exitScope()
 
-	fi, err := os.Stat(opts.Positional.Input)
+	inputIsBlockDevice, err := fs.PathIsBlockDevice(opts.Positional.Input)
 	if err != nil {
-		return xerrors.Errorf("cannot obtain source file information: %w", err)
+		return err
 	}
 
-	if opts.Output != "" && fi.Mode()&os.ModeDevice != 0 {
+	if opts.Output != "" && inputIsBlockDevice {
 		return errors.New("cannot specify --output with a block device")
 	}
 
@@ -335,7 +335,7 @@ func (i *imageIntegrityProtector) run(opts *integrityOptions) error {
 		return err
 	}
 
-	if fi.Mode()&os.ModeDevice != 0 {
+	if inputIsBlockDevice {
 		// Source file is a block device
 		i.devPath = opts.Positional.Input
 		if i.isNbdDevice() {

--- a/integrity.go
+++ b/integrity.go
@@ -98,6 +98,8 @@ func (i *imageIntegrityProtector) prepareRootPartition() error {
 			fmt.Sprintf("%d", 1),
 			"--new",
 			fmt.Sprintf("%d:%d:%d", 1, i.rootPartition.StartingLBA, endingLBA),
+			"--change-name",
+			fmt.Sprintf("%d:%s", 1, "cloudimg-rootfs"),
 		)
 
 		if err := cmd.Run(); err != nil {

--- a/integrity.go
+++ b/integrity.go
@@ -106,11 +106,7 @@ func (i *imageIntegrityProtector) prepareRootPartition() error {
 			fmt.Sprintf("%d:%s", 1, "cloudimg-rootfs"),
 		)
 
-		if err := cmd.Run(); err != nil {
-			return err
-		}
-
-		return nil
+		return cmd.Run()
 	}
 
 	return i.repartition(action)
@@ -219,7 +215,7 @@ type ImageManifest struct {
 
 func (i *imageIntegrityProtector) integrityProtectImageOnDevice() error {
 	if i.devPath == "" {
-		panic("no device path")
+		log.Fatal("no device path")
 	}
 
 	i.enterScope()
@@ -240,8 +236,7 @@ func (i *imageIntegrityProtector) integrityProtectImageOnDevice() error {
 
 	log.Infoln("dm-verity root hash for the root partition: ", rootHash)
 
-	err = i.createOrUpdateVerityPartition(verityFilePath)
-	if err != nil {
+	if err = i.createOrUpdateVerityPartition(verityFilePath); err != nil {
 		return err
 	}
 

--- a/integrity.go
+++ b/integrity.go
@@ -60,8 +60,8 @@ func (o *integrityOptions) GetOutput() string {
 	return o.Output
 }
 
-func sectorsFromBlocks(blockCount uint64) uint64 {
-	fsSize := blockCount * fs.BlockSize
+func sectorsFromBlocks(fsBlockCount uint64, fsBlockSize uint64) uint64 {
+	fsSize := fsBlockCount * fsBlockSize
 	// gpt.BlockSize corresponds to the sector size
 	fsSectors := fsSize / gpt.BlockSize
 	// partitions are aligned to 2048-sector boundaries
@@ -95,12 +95,12 @@ func (i *imageIntegrityProtector) prepareRootPartition() error {
 
 	log.Infoln("resizing partition", devPath)
 
-	blockCount, err := fs.GetBlockCount(devPath)
+	fsBlockCount, fsBlockSize, err := fs.GetBlockInfo(devPath)
 	if err != nil {
 		return err
 	}
 
-	endingLBA := uint64(i.rootPartition.StartingLBA) + sectorsFromBlocks(blockCount) - 1
+	endingLBA := uint64(i.rootPartition.StartingLBA) + sectorsFromBlocks(fsBlockCount, fsBlockSize) - 1
 
 	action := func() error {
 		cmd = internal_exec.LoggedCommand("sgdisk",

--- a/integrity.go
+++ b/integrity.go
@@ -200,7 +200,7 @@ func (i *imageIntegrityProtector) createOrUpdateVerityPartition(verityFilePath s
 
 // These match the structs in snap-bootstrap
 type ImageManifestPartition struct {
-	FsLabel  string `json:"label"`
+	GptLabel string `json:"label"`
 	RootHash string `json:"root_hash"`
 	Overlay  string `json:"overlay"`
 }
@@ -240,7 +240,7 @@ func (i *imageIntegrityProtector) integrityProtectImageOnDevice() error {
 	log.Infoln("generating manifest with integrity information for image on", i.devPath)
 
 	partition := ImageManifestPartition{
-		FsLabel:  "cloudimg-rootfs",
+		GptLabel: "cloudimg-rootfs",
 		RootHash: rootHash,
 		Overlay:  "lowerdir",
 	}

--- a/integrity.go
+++ b/integrity.go
@@ -131,6 +131,8 @@ func (i *imageIntegrityProtector) createIntegrityDataForRootPartition() (string,
 func (i *imageIntegrityProtector) createVerityPartition(size uint64) error {
 	action := func() error {
 		if i.verity != nil {
+			log.Infoln("deleting existing verity partition")
+
 			cmd := internal_exec.LoggedCommand("sgdisk",
 				i.imagePath,
 				"--delete",
@@ -142,7 +144,7 @@ func (i *imageIntegrityProtector) createVerityPartition(size uint64) error {
 			}
 		}
 
-		// create new partition
+		log.Infoln("creating a new verity partition")
 
 		// align to the next 2048-sector boundary
 		verityPartitionStart := i.rootPartition.EndingLBA/2048*2048 + 2048

--- a/integrity.go
+++ b/integrity.go
@@ -32,7 +32,6 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	snapd_dmverity "github.com/snapcore/snapd/snap/integrity/dmverity"
-	"golang.org/x/xerrors"
 )
 
 const (
@@ -274,7 +273,7 @@ func (i *imageIntegrityProtector) integrityProtectImageOnDevice() error {
 
 	log.Infoln("creating manifest under", ukiRootPath)
 	if err := os.WriteFile(filepath.Join(ukiRootPath, "manifest.json"), imJson, 0644); err != nil {
-		return xerrors.Errorf("cannot create manifest file: %w", err)
+		return fmt.Errorf("cannot create manifest file: %w", err)
 	}
 
 	return nil
@@ -284,7 +283,7 @@ func (i *imageIntegrityProtector) integrityProtectImageFromFile() error {
 	path, err := i.prepareWorkingImage(i.opts)
 	switch {
 	case err != nil:
-		return xerrors.Errorf("cannot prepare working image: %w", err)
+		return fmt.Errorf("cannot prepare working image: %w", err)
 	case path != "":
 		// We aren't encrypting the source image
 		i.addCleanup(func() error {
@@ -292,7 +291,7 @@ func (i *imageIntegrityProtector) integrityProtectImageFromFile() error {
 				return nil
 			}
 			if err := os.Rename(path, i.opts.Output); err != nil {
-				return xerrors.Errorf("cannot move working image to final path: %w", err)
+				return fmt.Errorf("cannot move working image to final path: %w", err)
 			}
 			return nil
 		})

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 
@@ -40,4 +41,13 @@ func GetBlockCount(devPath string) (uint64, error) {
 	}
 
 	return uint64(blockCount), nil
+}
+
+func PathIsBlockDevice(path string) (bool, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return false, fmt.Errorf("cannot obtain source file information: %w", err)
+	}
+
+	return fi.Mode()&os.ModeDevice != 0, nil
 }

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1,0 +1,43 @@
+package fs
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+
+	internal_exec "github.com/canonical/encrypt-cloud-image/internal/exec"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	BlockSize = 4096
+)
+
+var (
+	blockCountPatternRe = regexp.MustCompile(`Block count: *([0-9]*)`)
+)
+
+func GetBlockCount(devPath string) (uint64, error) {
+	log.Infoln("calculate filesystem block count on", devPath)
+
+	cmd := internal_exec.LoggedCommand("tune2fs",
+		"-l",
+		devPath)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return 0, err
+	}
+
+	matches := blockCountPatternRe.FindSubmatch(output)
+	if len(matches) < 2 {
+		return 0, fmt.Errorf("unable to determine block size for filesystem on %s", devPath)
+	}
+
+	blockCount, err := strconv.Atoi(string(matches[1]))
+	if err != nil {
+		return 0, err
+	}
+
+	return uint64(blockCount), nil
+}

--- a/main.go
+++ b/main.go
@@ -296,6 +296,9 @@ func (b *encryptCloudImageBase) detectPartitions() error {
 	return nil
 }
 
+// repartition is used to wrap a partitioning related input action between a
+// disconnect and reconnect operation. After a partitioning action, partition
+// modifications need to be re-detected as well.
 func (b *encryptCloudImageBase) repartition(action func() error) error {
 	log.Infoln("disconnecting", b.imagePath, "for repartitioning")
 	if err := b.disconnectNbd(); err != nil {

--- a/main.go
+++ b/main.go
@@ -98,6 +98,15 @@ func (b *encryptCloudImageBase) getDevPathFormat() (string, error) {
 	}
 }
 
+func (b *encryptCloudImageBase) getDevPath(i int) string {
+	devPathFormat, err := b.getDevPathFormat()
+	if err != nil {
+		log.Panicln(err.Error())
+	}
+
+	return fmt.Sprintf(devPathFormat, b.devPath, i)
+}
+
 func (b *encryptCloudImageBase) isNbdDevice() bool {
 	return strings.HasPrefix(b.devPath, "/dev/nbd")
 }
@@ -125,12 +134,7 @@ func (b *encryptCloudImageBase) rootDevPath() string {
 		log.Panicln("missing call to detectPartitions")
 	}
 
-	devPathFormat, err := b.getDevPathFormat()
-	if err != nil {
-		log.Panicln(err.Error())
-	}
-
-	return fmt.Sprintf(devPathFormat, b.devPath, b.rootPartition.Index)
+	return b.getDevPath(b.rootPartition.Index)
 }
 
 func (b *encryptCloudImageBase) espDevPath() string {
@@ -138,12 +142,7 @@ func (b *encryptCloudImageBase) espDevPath() string {
 		log.Panicln("missing call to detectPartitions")
 	}
 
-	devPathFormat, err := b.getDevPathFormat()
-	if err != nil {
-		log.Panicln(err.Error())
-	}
-
-	return fmt.Sprintf(devPathFormat, b.devPath, b.esp.Index)
+	return b.getDevPath(b.esp.Index)
 }
 
 func (b *encryptCloudImageBase) verityDevPath() string {
@@ -151,12 +150,7 @@ func (b *encryptCloudImageBase) verityDevPath() string {
 		return ""
 	}
 
-	devPathFormat, err := b.getDevPathFormat()
-	if err != nil {
-		log.Panicln(err.Error())
-	}
-
-	return fmt.Sprintf(devPathFormat, b.devPath, b.verity.Index)
+	return b.getDevPath(b.verity.Index)
 }
 
 func (b *encryptCloudImageBase) addCleanup(fn func() error) {

--- a/main.go
+++ b/main.go
@@ -237,7 +237,7 @@ func (b *encryptCloudImageBase) reconnectNbd() error {
 	// after calling connectNbd() will automatically cleanup the
 	// new connection instead.
 	if b.conn == nil {
-		panic("no existing connection found")
+		log.Fatal("no existing connection found")
 	}
 
 	log.Infoln("Reconnecting", b.imagePath)

--- a/main.go
+++ b/main.go
@@ -148,7 +148,7 @@ func (b *encryptCloudImageBase) espDevPath() string {
 
 func (b *encryptCloudImageBase) verityDevPath() string {
 	if b.verity == nil {
-		log.Panicln("missing call to detectPartitions")
+		return ""
 	}
 
 	devPathFormat, err := b.getDevPathFormat()
@@ -261,10 +261,9 @@ func (b *encryptCloudImageBase) detectPartitions() error {
 	b.esp = esp
 	log.Infoln("device node for ESP:", b.espDevPath())
 
+	// This can be return nil if a verity partition is not found in the image. This will be handled later
+	// by creating the needed partition.
 	verity := partitions.FindByPartitionName("cloudimg-rootfs-verity")
-	if verity == nil {
-		return fmt.Errorf("cannot find partition with the type %v on %s", rootVerityPartitionAmd64GUID, b.devPath)
-	}
 	log.Debugln("Root verity partition on", b.devPath, ":", verity)
 	b.verity = verity
 	log.Infoln("device node for verity:", b.verityDevPath())


### PR DESCRIPTION
The new `integrity-protect` command is used to calculate dm-verity data for the root partition of an image. The dm-verity data are included after the main root fs partition and will be discovered by snap-bootstrap using its filesystem label. The dm-verity root hash is included in a manifest.json file which is placed directly in the ESP. The dm-verity partition is partition number `2` and the idea is that there may be flexibility for multiple lower ro partitions in the future (`3` with `4` being its verity data etc.).

This implementation expects:
1. that snap-bootstrap will measure the manifest's contents before use and
2. an image which is deployed in a measured boot setup with a remote attestation scheme that verifies that the boot happened as expected (expected secure boot components + expected rootfs dm-verity hash).

`integrity-protect` can ran by itself for an integrity protected only ephemeral CVM or precede the `encrypt` and `deploy` steps of the standard flow to create an ntegrity protected and encrypted image for an ephemeral CVM.
