### PR TITLE
Introduce flags to specify partition types GUIDs

### DIFF
--- a/internal/gpt/gpt.go
+++ b/internal/gpt/gpt.go
@@ -42,6 +42,21 @@ type PartitionEntry struct {
 
 type Partitions []*PartitionEntry
 
+func (partitions Partitions) FindByUUID(s string) *PartitionEntry {
+	t, err := efi.DecodeGUIDString(s)
+	if err != nil {
+		return nil
+	}
+
+	for _, p := range partitions {
+		if p.UniquePartitionGUID == t {
+			return p
+		}
+	}
+
+	return nil
+}
+
 func (partitions Partitions) FindByPartitionType(t efi.GUID) *PartitionEntry {
 	for _, p := range partitions {
 		if p.PartitionTypeGUID == t {

--- a/internal/gpt/gpt_test.go
+++ b/internal/gpt/gpt_test.go
@@ -1,0 +1,53 @@
+package gpt
+
+import (
+	"crypto/rand"
+	"testing"
+
+	efi "github.com/canonical/go-efilib"
+)
+
+func generatePartitionEntry(t *testing.T) *PartitionEntry {
+	var GUID efi.GUID = [16]byte{}
+	_, err := rand.Read(GUID[:])
+	if err != nil {
+		// Per rand.Read doc, this should never happen:
+		//    Read fills b with cryptographically secure random bytes.
+		//    It never returns an error, and always fills b entirely.
+		t.Fatal("failed to generate random UUID")
+	}
+
+	return &PartitionEntry{
+		PartitionEntry: &efi.PartitionEntry{
+			UniquePartitionGUID: GUID,
+		},
+	}
+}
+
+func TestFindByUUID(t *testing.T) {
+	partition1 := generatePartitionEntry(t)
+	partition2 := generatePartitionEntry(t)
+	partition3 := generatePartitionEntry(t)
+
+	table := []struct {
+		Name          string
+		UUIDStr       string
+		Parts         Partitions
+		ExpectedEntry *PartitionEntry
+	}{
+		{"simple", partition3.UniquePartitionGUID.String(), Partitions{partition1, partition2, partition3}, partition3},
+		{"wrong UUID", "foobar", Partitions{partition1}, nil},
+		{"no partition", partition1.UniquePartitionGUID.String(), Partitions{}, nil},
+		{"no partition matching", partition1.UniquePartitionGUID.String(), Partitions{partition2, partition3}, nil},
+		{"nil partition list", partition1.UniquePartitionGUID.String(), nil, nil},
+	}
+
+	for _, testParams := range table {
+		t.Run(testParams.Name, func(t *testing.T) {
+			partition := testParams.Parts.FindByUUID(testParams.UUIDStr)
+			if partition != testParams.ExpectedEntry {
+				t.Errorf("Wrong partition entry returned by FindByUUID(%s) on %v. Got %v, expected %v.", testParams.UUIDStr, testParams.Parts, partition, testParams.ExpectedEntry)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Instead of only relying on partition type GUIDs to find the ESP and root
filesystem, this allows the user to explicitely specify which partition
UUID they want to use.