### PR TITLE
Stop using deprecated io/ioutil

### DIFF
--- a/create-uefi-config/main.go
+++ b/create-uefi-config/main.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -86,7 +85,7 @@ func populateConfigFromVars(config *efienv.Config) error {
 
 func populateConfigFromESLs(config *efienv.Config, path string) error {
 	pkPath := filepath.Join(path, "PK.esl")
-	pk, err := ioutil.ReadFile(pkPath)
+	pk, err := os.ReadFile(pkPath)
 	switch {
 	case err != nil && os.IsNotExist(err):
 	case err != nil:
@@ -198,7 +197,7 @@ func run(args []string) error {
 				src:  config.Dbx,
 			},
 		} {
-			if err := ioutil.WriteFile(filepath.Join(options.SaveDatabases, d.name), d.src, 0644); err != nil {
+			if err := os.WriteFile(filepath.Join(options.SaveDatabases, d.name), d.src, 0644); err != nil {
 				return xerrors.Errorf("cannot write file %s: %w", d.name, err)
 			}
 		}

--- a/deploy.go
+++ b/deploy.go
@@ -26,7 +26,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -105,7 +104,7 @@ func (d *imageDeployer) maybeAddRecoveryKey(key []byte) error {
 	}
 
 	log.Infoln("Adding recovery key to image")
-	b, err := ioutil.ReadFile(d.opts.RecoveryKeyFile)
+	b, err := os.ReadFile(d.opts.RecoveryKeyFile)
 	if err != nil {
 		return xerrors.Errorf("cannot read recovery key from file: %w", err)
 	}

--- a/encrypt.go
+++ b/encrypt.go
@@ -27,7 +27,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -327,7 +326,7 @@ datasource_list: [ %s ]
 `
 		datasourceContent := fmt.Sprintf(datasourceOverrideTmpl, e.opts.OverrideDatasources)
 
-		if err := ioutil.WriteFile(filepath.Join(cloudCfgDir, "99_datasources_override.cfg"), []byte(datasourceContent), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(cloudCfgDir, "99_datasources_override.cfg"), []byte(datasourceContent), 0644); err != nil {
 			return xerrors.Errorf("cannot create datasource override file: %w", err)
 		}
 	}
@@ -340,7 +339,7 @@ growpart:
     mode: off
 `
 
-		if err := ioutil.WriteFile(filepath.Join(cloudCfgDir, "99_disable_growpart.cfg"), []byte(disableGrowPart), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(cloudCfgDir, "99_disable_growpart.cfg"), []byte(disableGrowPart), 0644); err != nil {
 			return xerrors.Errorf("cannot create growpart override file: %w", err)
 		}
 	} else {
@@ -354,7 +353,7 @@ growpart:
 			return xerrors.Errorf("cannot marshal key data for growpart: %w", err)
 		}
 
-		if err := ioutil.WriteFile(filepath.Join(path, "cc_growpart_keydata"), b, 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(path, "cc_growpart_keydata"), b, 0600); err != nil {
 			return xerrors.Errorf("cannot write key data for growpart: %w", err)
 		}
 	}

--- a/internal/efienv/az_test.go
+++ b/internal/efienv/az_test.go
@@ -21,7 +21,6 @@ package efienv_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -75,7 +74,7 @@ func (s *azSuite) testNewEnvironmentFromAzDiskProfile(c *C, path string) {
 		c.Check(err, IsNil)
 		c.Check(attrs, Equals, efi.AttributeTimeBasedAuthenticatedWriteAccess|efi.AttributeRuntimeAccess|efi.AttributeBootserviceAccess|efi.AttributeNonVolatile)
 
-		expected, err := ioutil.ReadFile(filepath.Join("testdata", v.name))
+		expected, err := os.ReadFile(filepath.Join("testdata", v.name))
 		c.Check(err, IsNil)
 		c.Check(data, DeepEquals, expected)
 	}

--- a/internal/efienv/efienv_test.go
+++ b/internal/efienv/efienv_test.go
@@ -22,7 +22,6 @@ package efienv_test
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -234,7 +233,7 @@ func (s *efienvSuite) testNewEnvironment(c *C, data *testNewEnvironmentData) {
 		c.Check(err, IsNil)
 		c.Check(attrs, Equals, efi.AttributeTimeBasedAuthenticatedWriteAccess|efi.AttributeRuntimeAccess|efi.AttributeBootserviceAccess|efi.AttributeNonVolatile)
 
-		expected, err := ioutil.ReadFile(filepath.Join("testdata", v.name))
+		expected, err := os.ReadFile(filepath.Join("testdata", v.name))
 		c.Check(err, IsNil)
 		c.Check(data, DeepEquals, expected)
 	}

--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -134,7 +133,7 @@ func (s *execSuite) SetUpSuite(c *C) {
 	s.savedLevel = log.StandardLogger().Level
 	s.savedLogDest = log.StandardLogger().Out
 	log.SetLevel(log.DebugLevel)
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 
 	dir := c.MkDir()
 
@@ -350,7 +349,7 @@ func runChild() int {
 	}
 	defer f.Close()
 
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		fmt.Fprint(os.Stderr, err)
 		return 1

--- a/internal/luks2/fifo.go
+++ b/internal/luks2/fifo.go
@@ -21,7 +21,6 @@ package luks2
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -33,7 +32,7 @@ func mkFifo() (string, func(), error) {
 	// /run is not world writable but we create a unique directory here because this
 	// code can be invoked by a public API and we shouldn't fail if more than one
 	// process reaches here at the same time.
-	dir, err := ioutil.TempDir("/run", filepath.Base(os.Args[0])+".")
+	dir, err := os.MkdirTemp("/run", filepath.Base(os.Args[0])+".")
 	if err != nil {
 		return "", nil, xerrors.Errorf("cannot create temporary directory: %w", err)
 	}

--- a/internal/nbd/nbd.go
+++ b/internal/nbd/nbd.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -62,7 +61,7 @@ const (
 )
 
 func getMaxNBDs() (int, error) {
-	b, err := ioutil.ReadFile(filepath.Join(sysfsPath, "module/nbd/parameters/nbds_max"))
+	b, err := os.ReadFile(filepath.Join(sysfsPath, "module/nbd/parameters/nbds_max"))
 	if err != nil {
 		return 0, err
 	}
@@ -182,7 +181,7 @@ func (d nbdDev) sysfsPath() string {
 }
 
 func (d nbdDev) isManagedByProcess(pid int) (bool, error) {
-	b, err := ioutil.ReadFile(filepath.Join(d.sysfsPath(), "pid"))
+	b, err := os.ReadFile(filepath.Join(d.sysfsPath(), "pid"))
 	switch {
 	case os.IsNotExist(err):
 		return false, nil

--- a/internal/nbd/nbd_test.go
+++ b/internal/nbd/nbd_test.go
@@ -25,7 +25,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -125,7 +124,7 @@ exec %[1]s -mock-udevadm-monitor %[2]s
 
 func (s *nbdSuite) mockNbdModule(c *C, n int) {
 	c.Check(os.MkdirAll(filepath.Join(s.sysfsPath, "module/nbd/parameters"), 0755), IsNil)
-	c.Check(ioutil.WriteFile(filepath.Join(s.sysfsPath, "module/nbd/parameters/nbds_max"), []byte(strconv.Itoa(n)), 0644), IsNil)
+	c.Check(os.WriteFile(filepath.Join(s.sysfsPath, "module/nbd/parameters/nbds_max"), []byte(strconv.Itoa(n)), 0644), IsNil)
 }
 
 func (s *nbdSuite) waitForQemuNbd(path string, iter int) (int, error) {
@@ -197,7 +196,7 @@ func (s *nbdSuite) mockNbdConnection(path string, pid int) error {
 	if err := os.MkdirAll(sysfsPath, 0755); err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filepath.Join(sysfsPath, "pid"), []byte(strconv.Itoa(pid)), 0444)
+	return os.WriteFile(filepath.Join(sysfsPath, "pid"), []byte(strconv.Itoa(pid)), 0444)
 }
 
 func (s *nbdSuite) simulateKernelUevent(action, path, subsystem string) error {
@@ -415,7 +414,7 @@ func runMockQemuNbd() int {
 	}
 	defer f.Close()
 
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		fmt.Fprint(os.Stderr, err)
 		return 1

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -178,7 +178,7 @@ func (b *encryptCloudImageBase) exitScope() {
 }
 
 func (b *encryptCloudImageBase) setupWorkingDir(baseDir string) error {
-	name, err := ioutil.TempDir(baseDir, "encrypt-cloud-image.")
+	name, err := os.MkdirTemp(baseDir, "encrypt-cloud-image.")
 	if err != nil {
 		return xerrors.Errorf("cannot setup working directory: %w", err)
 	}
@@ -315,7 +315,7 @@ func checkPrerequisites() error {
 }
 
 func configureLogging() {
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 
 	w := logutil.NewFormattedWriter(
 		[]log.Level{

--- a/print-recovery-key/main.go
+++ b/print-recovery-key/main.go
@@ -22,7 +22,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/snapcore/secboot"
@@ -47,7 +46,7 @@ func main() {
 		r = f
 	}
 
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)


### PR DESCRIPTION
Per the package documentation:
  Deprecated: As of Go 1.16, the same functionality is now provided by
  package io or package os, and those implementations should be preferred
  in new code. See the specific function documentation for details.

Ref: https://pkg.go.dev/io/ioutil