### PR TITLE
Disable cgo during the build to build a static binary

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*.*.*"
 
+env:
+  CGO_ENABLED: 0
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+env:
+  CGO_ENABLED: 0
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -24,4 +27,3 @@ jobs:
       - name: Run unit tests
         run: |
           go test ./... -v
-


### PR DESCRIPTION
We don't need cgo and disabling it makes the binary that we build more portable.

With CGO_ENABLED=1:
  $ ldd encrypt-cloud-image; du -hs encrypt-cloud-image
          linux-vdso.so.1 (0x000074cbf1470000)
          libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x000074cbf1200000)
          /lib64/ld-linux-x86-64.so.2 (0x000074cbf1472000)
  11M     encrypt-cloud-image

With CGO_ENABLED=0:
  $ ldd encrypt-cloud-image; du -hs encrypt-cloud-image
          not a dynamic executable
  11M     encrypt-cloud-image