### PR TITLE
Build and attach all the binaries to releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,9 +21,9 @@ jobs:
           go-version: '>=1.13'
 
       - name: Build
-        run: go build -v -o . .
+        run: go build -v -o build ./...
 
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
-          files: encrypt-cloud-image
+          files: build/*

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ create-uefi-config/create-uefi-config
 encrypt-cloud-image
 internal/efienv/create-test-az-model/create-test-az-model
 print-recovery-key/print-recovery-key
+build


### PR DESCRIPTION
`encrypt-cloud-image` is not the only binary built from this repository. We also need to compile and attach the other binaries when we create a release.