### PR TITLE
Fix sphinx warning

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -139,7 +139,7 @@ html_context = {
     # Docs location in the repo; used in links for viewing the source files
     #
     # TODO: To customise the directory, uncomment and update as needed.
-    "github_folder": "/docs/",
+    "repo_folder": "/docs/",
     # TODO: To enable or disable the Previous / Next buttons at the bottom of pages
     # Valid options: none, prev, next, both
     # "sequential_nav": "both",


### PR DESCRIPTION
Sphinx is showing this warning:

  WARNING: conf.py setting 'github_folder' is deprecated. Use 'repo_folder' instead.

which makes the build fail because we set `fail_on_warning: true`