### PR TITLE
fix(action/release): fix build command to build in directory

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
           go-version: '>=1.13'
 
       - name: Build
-        run: go build -v -o build ./...
+        run: go build -v -o build/ ./...
 
       - name: Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Without /, the build fails with:
  go: cannot write multiple packages to non-directory build

To my defense, I tested both `build/` and `build` locally but I tried `build/` before `build` and `go build -o build` works if `build` already exists and is a directory.