### PR TITLE
docs: Add instructions on reporting a security issue

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+To report a security issue, file a [Private Security Report](https://github.com/canonical/encrypt-cloud-image/security/advisories/new) with a description of the issue,
+the steps you took to create the issue, affected versions, and, if known, mitigations for the issue.
+
+The [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy) contains more information about what you can expect when you contact
+us and what we expect from you.


### PR DESCRIPTION
This commit introduces a `SECURITY.md` file containing instructions on reporting a security issue.