### PR TITLE
feat: Replace argon2i with PBKDF2

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -110,7 +110,13 @@ func (d *imageDeployer) maybeAddRecoveryKey(key []byte) error {
 		return errors.New("recovery key must be 16 bytes")
 	}
 
-	return luks2.AddKey(d.rootDevPath(), key, b, nil)
+	opts := luks2.AddKeyOptions{
+		KDFOptions: luks2.KDFOptions{
+			ForceIterations: minimumPBKDF2Iterations,
+		},
+		Slot: luks2.AnySlot,
+	}
+	return luks2.AddKey(d.rootDevPath(), key, b, &opts)
 }
 
 func (d *imageDeployer) maybeWriteCustomSRKTemplate(esp string, srkPub *tpm2.Public) error {

--- a/encrypt.go
+++ b/encrypt.go
@@ -44,6 +44,8 @@ const (
 	luks2HeaderKiBSize   = 16 * 1024
 
 	luks2GrowPartKeyslot = 10
+
+	minimumPBKDF2Iterations = 1000
 )
 
 type encryptOptions struct {
@@ -96,10 +98,10 @@ func luks2Encrypt(path string, key []byte) error {
 		"--key-file", "-",
 		// use AES-256 with XTS block cipher mode (XTS requires 2 keys)
 		"--cipher", "aes-xts-plain64", "--key-size", "512",
-		// use argon2i as the KDF
-		"--pbkdf", "argon2i",
-		// set the minimum KDF cost parameters
-		"--pbkdf-force-iterations", "4", "--pbkdf-memory", "32768",
+		// use PBKDF2 as the KDF
+		"--pbkdf", "pbkdf2",
+		// set the minimum number of PBKDF2 iterations
+		"--pbkdf-force-iterations", strconv.Itoa(minimumPBKDF2Iterations),
 		// set the default metadata size to 512KiB
 		"--luks2-metadata-size", fmt.Sprintf("%dk", luks2MetadataKiBSize),
 		// specify the keyslots area size of 16MiB - (2 * 512KiB)
@@ -392,8 +394,7 @@ func (e *imageEncrypter) encryptImageOnDevice() error {
 	if !e.opts.GrowRoot {
 		opts := luks2.AddKeyOptions{
 			KDFOptions: luks2.KDFOptions{
-				MemoryKiB:       32 * 1024,
-				ForceIterations: 4},
+				ForceIterations: minimumPBKDF2Iterations},
 			Slot: luks2GrowPartKeyslot}
 		if err := luks2.AddKey(e.rootDevPath(), key, growPartKey[:], &opts); err != nil {
 			return fmt.Errorf("cannot add key to container for cc_growpart: %w", err)

--- a/internal/luks2/cryptsetup.go
+++ b/internal/luks2/cryptsetup.go
@@ -27,7 +27,6 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
-	"time"
 
 	"github.com/snapcore/snapd/osutil"
 )
@@ -74,51 +73,17 @@ func cryptsetupCmd(stdin io.Reader, callback func(cmd *exec.Cmd) error, args ...
 	return nil
 }
 
-// KDFOptions specifies parameters for the Argon2 KDF.
+// KDFOptions specifies parameters for PBKDF2.
 type KDFOptions struct {
-	// TargetDuration specifies the target time for benchmarking of the
-	// time and memory cost parameters. If it is zero then the cryptsetup
-	// default is used. If ForceIterations is not zero then this is ignored.
-	TargetDuration time.Duration
-
-	// MemoryKiB specifies the maximum memory cost in KiB when ForceIterations
-	// is zero, or the actual memory cost in KiB when ForceIterations is not zero.
-	// If this is set to zero, then the cryptsetup default is used.
-	MemoryKiB int
-
-	// ForceIterations specifies the time cost. If set to zero, the time
-	// and memory cost are determined by benchmarking the algorithm based on
-	// the specified TargetDuration. Set to a non-zero number to force the
-	// time cost to the value of this field, and the memory cost to the value
-	// of MemoryKiB, disabling benchmarking.
+	// ForceIterations specifies the iteration count.
 	ForceIterations int
-
-	// Parallel sets the maximum number of parallel threads. Cryptsetup may
-	// choose a lower value based on its own maximum and the number of available
-	// CPU cores.
-	Parallel int
 }
 
 func (options *KDFOptions) appendArguments(args []string) []string {
-	// use argon2i as the KDF
-	args = append(args, "--pbkdf", "argon2i")
+	args = append(args, "--pbkdf", "pbkdf2")
 
-	switch {
-	case options.ForceIterations != 0:
-		// Disable benchmarking by forcing the time cost
-		args = append(args,
-			"--pbkdf-force-iterations", strconv.Itoa(options.ForceIterations))
-	case options.TargetDuration != 0:
-		args = append(args,
-			"--iter-time", strconv.FormatInt(int64(options.TargetDuration/time.Millisecond), 10))
-	}
-
-	if options.MemoryKiB != 0 {
-		args = append(args, "--pbkdf-memory", strconv.Itoa(options.MemoryKiB))
-	}
-
-	if options.Parallel != 0 {
-		args = append(args, "--pbkdf-parallel", strconv.Itoa(options.Parallel))
+	if options.ForceIterations > 0 {
+		args = append(args, "--pbkdf-force-iterations", strconv.Itoa(options.ForceIterations))
 	}
 
 	return args
@@ -148,7 +113,7 @@ type FormatOptions struct {
 // called on a device that is not mapped.
 //
 // The container will be configured to encrypt data with AES-256 and XTS block cipher mode. The
-// KDF for the primary keyslot will be configured to use argon2i with the supplied benchmark time.
+// KDF for the primary keyslot will be PBKDF2 with the provided iteration count.
 //
 // WARNING: This function is destructive. Calling this on an existing LUKS2 container will make the
 // data contained inside of it irretrievable.
@@ -201,12 +166,11 @@ type AddKeyOptions struct {
 	Slot int
 }
 
-// AddKey adds the supplied key in to a new keyslot for specified LUKS2 container. In order to do this,
-// an existing key must be provided. The KDF for the new keyslot will be configured to use argon2i with
-// the supplied benchmark time. The key will be added to the supplied slot.
+// AddKey adds a key derived from a provided existing key to the provided key slot in the provided
+// LUKS2 container.
 //
-// If options is not supplied, the default KDF benchmark time is used and the command will
-// automatically choose an appropriate slot.
+// If options is not provided, the default key derivation iteration count will be used and key slot
+// selection will be delegated to cryptsetup.
 func AddKey(devicePath string, existingKey, key []byte, options *AddKeyOptions) error {
 	if options == nil {
 		options = &AddKeyOptions{Slot: AnySlot}


### PR DESCRIPTION
This commit replaces argon2i with PBKDF2 as the derivation function for LUKS2 container keys.